### PR TITLE
Add content write scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ keys/*.key
 .vscode/
 *.user
 *.suo
+*.local.http
 
 # Ignore build output
 bin/

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Users:
 | Username | Password | Role  | Scope        |
 | --- | --- | --- | --- |
 | `user` | `user123` | `User` | `content.read` |
-| `admin` | `admin123` | `Admin` | `content.read` |
+| `admin` | `admin123` | `Admin` | `content.read content.write` |
 
 Client:
 
 | Client ID | Client Secret | Scope |
 | --- | --- | --- |
-| `worker-service` | `worker-secret` | `content.read` |
+| `worker-service` | `worker-secret` | `content.read content.write` |
 
 These are lab credentials. Do not use committed secrets for real systems.
 
@@ -66,7 +66,7 @@ Response:
   "access_token": "<jwt>",
   "token_type": "Bearer",
   "expires_in": 1800,
-  "scope": "content.read"
+  "scope": "content.read content.write"
 }
 ```
 
@@ -102,6 +102,7 @@ The response shape is the same as login. Invalid clients return `invalid_client`
 | `GET /content/user` | Any valid bearer token |
 | `GET /content/admin` | `Admin` role |
 | `GET /content/read` | `content.read` scope |
+| `POST /content/write` | `content.write` scope |
 | `GET /content/service` | `token_type=service` |
 
 Example:
@@ -118,6 +119,8 @@ Use these files with Visual Studio, Rider, or the REST Client extension:
 - `backend/AuthFlowLab.http` contains the full Auth Server + API Server flow.
 - `backend/AuthFlowLab.AuthServer/AuthFlowLab.AuthServer.http` contains Auth Server requests.
 - `backend/AuthFlowLab.ApiServer/AuthFlowLab.ApiServer.http` contains API Server requests.
+
+Keep shared `.http` files token-free. If you want to store personal tokens locally, create a file such as `backend/AuthFlowLab.local.http`; `*.local.http` is ignored by Git.
 
 ## Tests
 

--- a/backend/AuthFlowLab.ApiServer.Tests/ContentEndpointTests.cs
+++ b/backend/AuthFlowLab.ApiServer.Tests/ContentEndpointTests.cs
@@ -51,6 +51,28 @@ public sealed class ContentEndpointTests : IClassFixture<ApiServerFactory>
     }
 
     [Fact]
+    public async Task WriteContent_RejectsUserWithoutContentWriteScope()
+    {
+        UseBearerToken(_factory.CreateToken("user", tokenType: "user", role: "User", scope: "content.read"));
+
+        var response = await _client.PostAsync("/content/write", content: null);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task WriteContent_AllowsAdminWithContentWriteScope()
+    {
+        UseBearerToken(_factory.CreateToken("admin", tokenType: "user", role: "Admin", scope: "content.read content.write"));
+
+        var response = await _client.PostAsync("/content/write", content: null);
+        var content = await response.Content.ReadAsStringAsync();
+
+        Assert.True(response.IsSuccessStatusCode, content);
+        Assert.Equal("Content write allowed", content);
+    }
+
+    [Fact]
     public async Task AdminContent_RequiresAdminRole()
     {
         UseBearerToken(_factory.CreateToken("user", tokenType: "user", role: "User", scope: "content.read"));
@@ -68,6 +90,18 @@ public sealed class ContentEndpointTests : IClassFixture<ApiServerFactory>
         var content = await _client.GetStringAsync("/content/service");
 
         Assert.Equal("Service-only content", content);
+    }
+
+    [Fact]
+    public async Task WriteContent_AllowsServiceWithContentWriteScope()
+    {
+        UseBearerToken(_factory.CreateToken("worker-service", tokenType: "service", scope: "content.read content.write"));
+
+        var response = await _client.PostAsync("/content/write", content: null);
+        var content = await response.Content.ReadAsStringAsync();
+
+        Assert.True(response.IsSuccessStatusCode, content);
+        Assert.Equal("Content write allowed", content);
     }
 
     private void UseBearerToken(string token)
@@ -118,6 +152,7 @@ public sealed class ApiServerFactory : WebApplicationFactory<Program>
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
+        builder.UseContentRoot(FindProjectDirectory("AuthFlowLab.ApiServer"));
         builder.ConfigureAppConfiguration((_, config) =>
         {
             config.AddInMemoryCollection(new Dictionary<string, string?>
@@ -125,5 +160,23 @@ public sealed class ApiServerFactory : WebApplicationFactory<Program>
                 ["Jwt:PublicKeyPath"] = _publicKeyPath
             });
         });
+    }
+
+    private static string FindProjectDirectory(string projectName)
+    {
+        var directory = new DirectoryInfo(Directory.GetCurrentDirectory());
+
+        while (directory is not null)
+        {
+            var projectDirectory = Path.Combine(directory.FullName, "backend", projectName);
+            if (File.Exists(Path.Combine(projectDirectory, $"{projectName}.csproj")))
+            {
+                return projectDirectory;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException($"Could not find project directory for {projectName}.");
     }
 }

--- a/backend/AuthFlowLab.ApiServer/AuthFlowLab.ApiServer.http
+++ b/backend/AuthFlowLab.ApiServer/AuthFlowLab.ApiServer.http
@@ -20,6 +20,11 @@ GET {{ApiServer}}/content/read
 Accept: application/json
 Authorization: Bearer {{AccessToken}}
 
+### Requires content.write scope
+POST {{ApiServer}}/content/write
+Accept: application/json
+Authorization: Bearer {{AccessToken}}
+
 ### Requires token_type=service
 GET {{ApiServer}}/content/service
 Accept: application/json

--- a/backend/AuthFlowLab.ApiServer/Controllers/ContentController.cs
+++ b/backend/AuthFlowLab.ApiServer/Controllers/ContentController.cs
@@ -27,6 +27,11 @@ public class ContentController : ControllerBase
     public IActionResult ReadContent()
         => Ok("Content read allowed");
 
+    [HttpPost("write")]
+    [Authorize(Policy = "ContentWrite")]
+    public IActionResult WriteContent()
+        => Ok("Content write allowed");
+
     [HttpGet("service")]
     [Authorize(Policy = "ServiceOnly")]
     public IActionResult ServiceContent()

--- a/backend/AuthFlowLab.ApiServer/Program.cs
+++ b/backend/AuthFlowLab.ApiServer/Program.cs
@@ -44,6 +44,13 @@ builder.Services.AddAuthorization(options =>
             .Contains("content.read", StringComparer.Ordinal);
     }));
 
+    options.AddPolicy("ContentWrite", policy => policy.RequireAssertion(context =>
+    {
+        return context.User.FindAll("scope")
+            .SelectMany(claim => claim.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .Contains("content.write", StringComparer.Ordinal);
+    }));
+
     options.AddPolicy("ServiceOnly", policy => policy.RequireAssertion(context =>
     {
         return context.User.HasClaim(c => c.Type == "token_type" && c.Value == "service");

--- a/backend/AuthFlowLab.AuthServer.Tests/AuthEndpointTests.cs
+++ b/backend/AuthFlowLab.AuthServer.Tests/AuthEndpointTests.cs
@@ -22,7 +22,7 @@ public sealed class AuthEndpointTests : IClassFixture<AuthServerFactory>
     {
         var response = await _client.PostAsJsonAsync("/auth/login", new
         {
-            username = "user",
+            username = "test-user",
             password = "user123"
         });
 
@@ -37,11 +37,26 @@ public sealed class AuthEndpointTests : IClassFixture<AuthServerFactory>
     }
 
     [Fact]
+    public async Task Login_Returns_AdminWriteScope()
+    {
+        var response = await _client.PostAsJsonAsync("/auth/login", new
+        {
+            username = "test-admin",
+            password = "admin123"
+        });
+
+        response.EnsureSuccessStatusCode();
+        var token = await response.Content.ReadFromJsonAsync<TokenResponse>();
+
+        Assert.Equal("content.read content.write", token?.Scope);
+    }
+
+    [Fact]
     public async Task Login_WithBadPassword_ReturnsInvalidGrant()
     {
         var response = await _client.PostAsJsonAsync("/auth/login", new
         {
-            username = "user",
+            username = "test-user",
             password = "wrong"
         });
 
@@ -58,7 +73,7 @@ public sealed class AuthEndpointTests : IClassFixture<AuthServerFactory>
         {
             clientId = "worker-service",
             clientSecret = "worker-secret",
-            scope = "content.read"
+            scope = "content.read content.write"
         });
 
         response.EnsureSuccessStatusCode();
@@ -66,7 +81,7 @@ public sealed class AuthEndpointTests : IClassFixture<AuthServerFactory>
 
         Assert.NotNull(token);
         Assert.Equal("Bearer", token.TokenType);
-        Assert.Equal("content.read", token.Scope);
+        Assert.Equal("content.read content.write", token.Scope);
         Assert.False(string.IsNullOrWhiteSpace(token.AccessToken));
     }
 
@@ -100,21 +115,46 @@ public sealed class AuthServerFactory : WebApplicationFactory<Program>
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
+        builder.UseContentRoot(FindProjectDirectory("AuthFlowLab.AuthServer"));
         builder.ConfigureAppConfiguration((_, config) =>
         {
             config.AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["Jwt:PrivateKeyPath"] = _privateKeyPath,
                 ["Auth:AccessTokenMinutes"] = "10",
-                ["Auth:Users:0:Username"] = "user",
-                ["Auth:Users:0:Password"] = "user123",
-                ["Auth:Users:0:Role"] = "User",
+                ["Auth:Users:0:Username"] = "test-admin",
+                ["Auth:Users:0:Password"] = "admin123",
+                ["Auth:Users:0:Role"] = "Admin",
                 ["Auth:Users:0:Scopes:0"] = "content.read",
+                ["Auth:Users:0:Scopes:1"] = "content.write",
+                ["Auth:Users:1:Username"] = "test-user",
+                ["Auth:Users:1:Password"] = "user123",
+                ["Auth:Users:1:Role"] = "User",
+                ["Auth:Users:1:Scopes:0"] = "content.read",
                 ["Auth:Clients:0:ClientId"] = "worker-service",
                 ["Auth:Clients:0:ClientSecret"] = "worker-secret",
-                ["Auth:Clients:0:Scopes:0"] = "content.read"
+                ["Auth:Clients:0:Scopes:0"] = "content.read",
+                ["Auth:Clients:0:Scopes:1"] = "content.write"
             });
         });
+    }
+
+    private static string FindProjectDirectory(string projectName)
+    {
+        var directory = new DirectoryInfo(Directory.GetCurrentDirectory());
+
+        while (directory is not null)
+        {
+            var projectDirectory = Path.Combine(directory.FullName, "backend", projectName);
+            if (File.Exists(Path.Combine(projectDirectory, $"{projectName}.csproj")))
+            {
+                return projectDirectory;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException($"Could not find project directory for {projectName}.");
     }
 }
 

--- a/backend/AuthFlowLab.AuthServer/AuthFlowLab.AuthServer.http
+++ b/backend/AuthFlowLab.AuthServer/AuthFlowLab.AuthServer.http
@@ -31,7 +31,7 @@ Accept: application/json
 {
   "clientId": "worker-service",
   "clientSecret": "worker-secret",
-  "scope": "content.read"
+  "scope": "content.read content.write"
 }
 
 ### Invalid login returns an OAuth-style error

--- a/backend/AuthFlowLab.AuthServer/appsettings.Development.json
+++ b/backend/AuthFlowLab.AuthServer/appsettings.Development.json
@@ -17,7 +17,7 @@
         "Username": "admin",
         "Password": "admin123",
         "Role": "Admin",
-        "Scopes": [ "content.read" ]
+        "Scopes": [ "content.read", "content.write" ]
       },
       {
         "Username": "user",
@@ -30,7 +30,7 @@
       {
         "ClientId": "worker-service",
         "ClientSecret": "worker-secret",
-        "Scopes": [ "content.read" ]
+        "Scopes": [ "content.read", "content.write" ]
       }
     ]
   }

--- a/backend/AuthFlowLab.AuthServer/appsettings.json
+++ b/backend/AuthFlowLab.AuthServer/appsettings.json
@@ -17,7 +17,7 @@
         "Username": "admin",
         "Password": "admin123",
         "Role": "Admin",
-        "Scopes": [ "content.read" ]
+        "Scopes": [ "content.read", "content.write" ]
       },
       {
         "Username": "user",
@@ -30,7 +30,7 @@
       {
         "ClientId": "worker-service",
         "ClientSecret": "worker-secret",
-        "Scopes": [ "content.read" ]
+        "Scopes": [ "content.read", "content.write" ]
       }
     ]
   },

--- a/backend/AuthFlowLab.http
+++ b/backend/AuthFlowLab.http
@@ -22,6 +22,11 @@ GET {{ApiServer}}/content/read
 Accept: application/json
 Authorization: Bearer {{userLogin.response.body.$.access_token}}
 
+### Normal user cannot access content.write policy
+POST {{ApiServer}}/content/write
+Accept: application/json
+Authorization: Bearer {{userLogin.response.body.$.access_token}}
+
 ### Admin login
 # @name adminLogin
 POST {{AuthServer}}/auth/login
@@ -38,6 +43,11 @@ GET {{ApiServer}}/content/admin
 Accept: application/json
 Authorization: Bearer {{adminLogin.response.body.$.access_token}}
 
+### Admin token can access content.write policy
+POST {{ApiServer}}/content/write
+Accept: application/json
+Authorization: Bearer {{adminLogin.response.body.$.access_token}}
+
 ### Client credentials-style service token
 # @name serviceToken
 POST {{AuthServer}}/auth/client-token
@@ -47,7 +57,7 @@ Accept: application/json
 {
   "clientId": "worker-service",
   "clientSecret": "worker-secret",
-  "scope": "content.read"
+  "scope": "content.read content.write"
 }
 
 ### Service token can access service-only content
@@ -57,5 +67,10 @@ Authorization: Bearer {{serviceToken.response.body.$.access_token}}
 
 ### Service token can also access content.read
 GET {{ApiServer}}/content/read
+Accept: application/json
+Authorization: Bearer {{serviceToken.response.body.$.access_token}}
+
+### Service token can also access content.write
+POST {{ApiServer}}/content/write
 Accept: application/json
 Authorization: Bearer {{serviceToken.response.body.$.access_token}}


### PR DESCRIPTION
## Summary
- add `content.write` scope to admin and service client configuration
- add `POST /content/write` protected by a new `ContentWrite` policy
- keep shared `.http` files token-free and ignore `*.local.http` for personal token experiments
- update README, HTTP examples, and integration tests for write-scope behavior

## Verification
- `dotnet test backend\AuthFlowLab.sln`