### PR TITLE
Add Swagger to API server

### DIFF
--- a/backend/AuthFlowLab.ApiServer/AuthFlowLab.ApiServer.csproj
+++ b/backend/AuthFlowLab.ApiServer/AuthFlowLab.ApiServer.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>
 
 </Project>

--- a/backend/AuthFlowLab.ApiServer/Program.cs
+++ b/backend/AuthFlowLab.ApiServer/Program.cs
@@ -1,11 +1,39 @@
 using System.Security.Claims;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.OpenApi;
 using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "AuthFlowLab API Server",
+        Version = "v1"
+    });
+
+    options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer",
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header,
+        Description = "Paste a JWT access token. The 'Bearer' prefix is optional."
+    });
+
+    options.AddSecurityRequirement(document => new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecuritySchemeReference("Bearer", document),
+            []
+        }
+    });
+});
 
 var publicKeyPath = builder.Configuration["Jwt:PublicKeyPath"] ?? "../../keys/public.key";
 publicKeyPath = Path.IsPathRooted(publicKeyPath)
@@ -58,6 +86,9 @@ builder.Services.AddAuthorization(options =>
 });
 
 var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
 app.UseAuthentication();


### PR DESCRIPTION
## Summary
- add Swashbuckle to ApiServer
- enable Swagger JSON and Swagger UI
- configure Bearer JWT security input for protected endpoints

## Verification
- `dotnet test backend\AuthFlowLab.sln`