### PR TITLE
Implement client credentials token endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,20 +79,21 @@ Invalid credentials return:
 }
 ```
 
-### Service Token
+### Client Credentials Token
 
 ```http
-POST http://127.0.0.1:5001/auth/client-token
-Content-Type: application/json
+POST http://127.0.0.1:5001/connect/token
+Content-Type: application/x-www-form-urlencoded
 
-{
-  "clientId": "worker-service",
-  "clientSecret": "worker-secret",
-  "scope": "content.read"
-}
+grant_type=client_credentials
+&client_id=worker-service
+&client_secret=worker-secret
+&scope=content.read content.write
 ```
 
-The response shape is the same as login. Invalid clients return `invalid_client`; disallowed scopes return `invalid_scope`.
+The response shape is the same as login. Invalid clients return `invalid_client`; unsupported grant types return `unsupported_grant_type`; disallowed scopes return `invalid_scope`.
+
+The old lab-only `/auth/client-token` endpoint has been removed. Service tokens now use the OAuth2-style `/connect/token` endpoint.
 
 ## API Server Endpoints
 

--- a/backend/AuthFlowLab.AuthServer.Tests/AuthEndpointTests.cs
+++ b/backend/AuthFlowLab.AuthServer.Tests/AuthEndpointTests.cs
@@ -67,14 +67,15 @@ public sealed class AuthEndpointTests : IClassFixture<AuthServerFactory>
     }
 
     [Fact]
-    public async Task ClientToken_WithAllowedScope_Returns_ServiceToken()
+    public async Task Token_WithClientCredentials_Returns_ServiceToken()
     {
-        var response = await _client.PostAsJsonAsync("/auth/client-token", new
+        var response = await _client.PostAsync("/connect/token", new FormUrlEncodedContent(new Dictionary<string, string>
         {
-            clientId = "worker-service",
-            clientSecret = "worker-secret",
-            scope = "content.read content.write"
-        });
+            ["grant_type"] = "client_credentials",
+            ["client_id"] = "worker-service",
+            ["client_secret"] = "worker-secret",
+            ["scope"] = "content.read content.write"
+        }));
 
         response.EnsureSuccessStatusCode();
         var token = await response.Content.ReadFromJsonAsync<TokenResponse>();
@@ -86,19 +87,49 @@ public sealed class AuthEndpointTests : IClassFixture<AuthServerFactory>
     }
 
     [Fact]
-    public async Task ClientToken_WithDisallowedScope_ReturnsInvalidScope()
+    public async Task Token_WithDisallowedScope_ReturnsInvalidScope()
     {
-        var response = await _client.PostAsJsonAsync("/auth/client-token", new
+        var response = await _client.PostAsync("/connect/token", new FormUrlEncodedContent(new Dictionary<string, string>
         {
-            clientId = "worker-service",
-            clientSecret = "worker-secret",
-            scope = "admin"
-        });
+            ["grant_type"] = "client_credentials",
+            ["client_id"] = "worker-service",
+            ["client_secret"] = "worker-secret",
+            ["scope"] = "admin"
+        }));
 
         var error = await response.Content.ReadFromJsonAsync<AuthErrorResponse>();
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         Assert.Equal("invalid_scope", error?.Error);
+    }
+
+    [Fact]
+    public async Task Token_WithUnsupportedGrantType_ReturnsUnsupportedGrantType()
+    {
+        var response = await _client.PostAsync("/connect/token", new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["client_id"] = "worker-service",
+            ["client_secret"] = "worker-secret"
+        }));
+
+        var error = await response.Content.ReadFromJsonAsync<AuthErrorResponse>();
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("unsupported_grant_type", error?.Error);
+    }
+
+    [Fact]
+    public async Task DeprecatedClientTokenEndpoint_ReturnsNotFound()
+    {
+        var response = await _client.PostAsJsonAsync("/auth/client-token", new
+        {
+            clientId = "worker-service",
+            clientSecret = "worker-secret",
+            scope = "content.read"
+        });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 }
 
@@ -133,6 +164,7 @@ public sealed class AuthServerFactory : WebApplicationFactory<Program>
                 ["Auth:Users:1:Scopes:0"] = "content.read",
                 ["Auth:Clients:0:ClientId"] = "worker-service",
                 ["Auth:Clients:0:ClientSecret"] = "worker-secret",
+                ["Auth:Clients:0:AllowedGrantTypes:0"] = "client_credentials",
                 ["Auth:Clients:0:Scopes:0"] = "content.read",
                 ["Auth:Clients:0:Scopes:1"] = "content.write"
             });

--- a/backend/AuthFlowLab.AuthServer/AuthFlowLab.AuthServer.http
+++ b/backend/AuthFlowLab.AuthServer/AuthFlowLab.AuthServer.http
@@ -22,17 +22,16 @@ Accept: application/json
   "password": "admin123"
 }
 
-### Issue a service token
+### Issue a service token with client_credentials
 # @name clientToken
-POST {{AuthServer}}/auth/client-token
-Content-Type: application/json
+POST {{AuthServer}}/connect/token
+Content-Type: application/x-www-form-urlencoded
 Accept: application/json
 
-{
-  "clientId": "worker-service",
-  "clientSecret": "worker-secret",
-  "scope": "content.read content.write"
-}
+grant_type=client_credentials
+&client_id=worker-service
+&client_secret=worker-secret
+&scope=content.read content.write
 
 ### Invalid login returns an OAuth-style error
 POST {{AuthServer}}/auth/login

--- a/backend/AuthFlowLab.AuthServer/Controllers/AuthController.cs
+++ b/backend/AuthFlowLab.AuthServer/Controllers/AuthController.cs
@@ -35,30 +35,4 @@ public class AuthController : ControllerBase
         return Ok(_jwtService.GenerateUserToken(user.Username, user.Role, user.Scopes));
     }
 
-    [HttpPost("client-token")]
-    public IActionResult ClientToken(ClientTokenRequest request)
-    {
-        var client = _authOptions.Clients.FirstOrDefault(client =>
-            client.ClientId == request.ClientId && client.ClientSecret == request.ClientSecret);
-
-        if (client is null)
-        {
-            return Unauthorized(new AuthErrorResponse(
-                "invalid_client",
-                "The client id or secret is invalid."));
-        }
-
-        var requestedScopes = string.IsNullOrWhiteSpace(request.Scope)
-            ? client.Scopes
-            : request.Scope.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
-
-        if (requestedScopes.Any(scope => !client.Scopes.Contains(scope, StringComparer.Ordinal)))
-        {
-            return BadRequest(new AuthErrorResponse(
-                "invalid_scope",
-                "The requested scope is not allowed for this client."));
-        }
-
-        return Ok(_jwtService.GenerateServiceToken(client.ClientId, requestedScopes));
-    }
 }

--- a/backend/AuthFlowLab.AuthServer/Controllers/ConnectController.cs
+++ b/backend/AuthFlowLab.AuthServer/Controllers/ConnectController.cs
@@ -1,0 +1,76 @@
+using AuthFlowLab.AuthServer.Models;
+using AuthFlowLab.AuthServer.Options;
+using AuthFlowLab.AuthServer.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace AuthFlowLab.AuthServer.Controllers;
+
+[ApiController]
+[Route("connect")]
+public class ConnectController : ControllerBase
+{
+    private const string ClientCredentialsGrantType = "client_credentials";
+
+    private readonly JwtService _jwtService;
+    private readonly AuthOptions _authOptions;
+
+    public ConnectController(JwtService jwtService, IOptions<AuthOptions> authOptions)
+    {
+        _jwtService = jwtService;
+        _authOptions = authOptions.Value;
+    }
+
+    [HttpPost("token")]
+    [Consumes("application/x-www-form-urlencoded")]
+    public IActionResult Token(
+        [FromForm(Name = "grant_type")] string? grantType,
+        [FromForm(Name = "client_id")] string? clientId,
+        [FromForm(Name = "client_secret")] string? clientSecret,
+        [FromForm(Name = "scope")] string? scope)
+    {
+        if (string.IsNullOrWhiteSpace(grantType))
+        {
+            return BadRequest(new AuthErrorResponse(
+                "invalid_request",
+                "The grant_type form field is required."));
+        }
+
+        if (grantType != ClientCredentialsGrantType)
+        {
+            return BadRequest(new AuthErrorResponse(
+                "unsupported_grant_type",
+                "Only client_credentials is supported by this token endpoint."));
+        }
+
+        var client = _authOptions.Clients.FirstOrDefault(client =>
+            client.ClientId == clientId && client.ClientSecret == clientSecret);
+
+        if (client is null)
+        {
+            return Unauthorized(new AuthErrorResponse(
+                "invalid_client",
+                "The client id or secret is invalid."));
+        }
+
+        if (!client.AllowedGrantTypes.Contains(ClientCredentialsGrantType, StringComparer.Ordinal))
+        {
+            return BadRequest(new AuthErrorResponse(
+                "unauthorized_client",
+                "The client is not allowed to use the requested grant type."));
+        }
+
+        var requestedScopes = string.IsNullOrWhiteSpace(scope)
+            ? client.Scopes
+            : scope.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+
+        if (requestedScopes.Any(requestedScope => !client.Scopes.Contains(requestedScope, StringComparer.Ordinal)))
+        {
+            return BadRequest(new AuthErrorResponse(
+                "invalid_scope",
+                "The requested scope is not allowed for this client."));
+        }
+
+        return Ok(_jwtService.GenerateServiceToken(client.ClientId, requestedScopes));
+    }
+}

--- a/backend/AuthFlowLab.AuthServer/Models/ClientTokenRequest.cs
+++ b/backend/AuthFlowLab.AuthServer/Models/ClientTokenRequest.cs
@@ -1,3 +1,0 @@
-namespace AuthFlowLab.AuthServer.Models;
-
-public record ClientTokenRequest(string ClientId, string ClientSecret, string? Scope = null);

--- a/backend/AuthFlowLab.AuthServer/Options/AuthOptions.cs
+++ b/backend/AuthFlowLab.AuthServer/Options/AuthOptions.cs
@@ -26,5 +26,7 @@ public sealed class AuthClient
 
     public string ClientSecret { get; init; } = "";
 
+    public List<string> AllowedGrantTypes { get; init; } = [];
+
     public List<string> Scopes { get; init; } = [];
 }

--- a/backend/AuthFlowLab.AuthServer/appsettings.Development.json
+++ b/backend/AuthFlowLab.AuthServer/appsettings.Development.json
@@ -30,6 +30,7 @@
       {
         "ClientId": "worker-service",
         "ClientSecret": "worker-secret",
+        "AllowedGrantTypes": [ "client_credentials" ],
         "Scopes": [ "content.read", "content.write" ]
       }
     ]

--- a/backend/AuthFlowLab.AuthServer/appsettings.json
+++ b/backend/AuthFlowLab.AuthServer/appsettings.json
@@ -30,6 +30,7 @@
       {
         "ClientId": "worker-service",
         "ClientSecret": "worker-secret",
+        "AllowedGrantTypes": [ "client_credentials" ],
         "Scopes": [ "content.read", "content.write" ]
       }
     ]

--- a/backend/AuthFlowLab.http
+++ b/backend/AuthFlowLab.http
@@ -50,15 +50,14 @@ Authorization: Bearer {{adminLogin.response.body.$.access_token}}
 
 ### Client credentials-style service token
 # @name serviceToken
-POST {{AuthServer}}/auth/client-token
-Content-Type: application/json
+POST {{AuthServer}}/connect/token
+Content-Type: application/x-www-form-urlencoded
 Accept: application/json
 
-{
-  "clientId": "worker-service",
-  "clientSecret": "worker-secret",
-  "scope": "content.read content.write"
-}
+grant_type=client_credentials
+&client_id=worker-service
+&client_secret=worker-secret
+&scope=content.read content.write
 
 ### Service token can access service-only content
 GET {{ApiServer}}/content/service


### PR DESCRIPTION
## Summary
- add OAuth2-style `POST /connect/token` endpoint for `grant_type=client_credentials`
- accept `application/x-www-form-urlencoded` token requests with `client_id`, `client_secret`, and `scope`
- validate allowed grant types and requested scopes from client configuration
- remove the old lab-only `/auth/client-token` endpoint
- update README and `.http` examples

## Verification
- `dotnet test backend\AuthFlowLab.sln`