### PR TITLE
Add Chinese auth flow comments

### DIFF
--- a/backend/AuthFlowLab.ApiServer/AuthFlowLab.ApiServer.http
+++ b/backend/AuthFlowLab.ApiServer/AuthFlowLab.ApiServer.http
@@ -2,30 +2,36 @@
 @AccessToken = paste-token-here
 
 ### Public content does not require a token
+# 匿名接口：不走 Bearer token 验证。
 GET {{ApiServer}}/content/public
 Accept: application/json
 
 ### Authenticated user or service
+# 基础认证：token 有效即可。
 GET {{ApiServer}}/content/user
 Accept: application/json
 Authorization: Bearer {{AccessToken}}
 
 ### Admin role only
+# 角色授权：需要 role=Admin。
 GET {{ApiServer}}/content/admin
 Accept: application/json
 Authorization: Bearer {{AccessToken}}
 
 ### Requires content.read scope
+# scope 授权：需要 content.read。
 GET {{ApiServer}}/content/read
 Accept: application/json
 Authorization: Bearer {{AccessToken}}
 
 ### Requires content.write scope
+# scope 授权：需要 content.write。
 POST {{ApiServer}}/content/write
 Accept: application/json
 Authorization: Bearer {{AccessToken}}
 
 ### Requires token_type=service
+# 自定义 claim 授权：需要 token_type=service。
 GET {{ApiServer}}/content/service
 Accept: application/json
 Authorization: Bearer {{AccessToken}}

--- a/backend/AuthFlowLab.ApiServer/Controllers/ContentController.cs
+++ b/backend/AuthFlowLab.ApiServer/Controllers/ContentController.cs
@@ -7,31 +7,37 @@ namespace AuthFlowLab.ApiServer.Controllers;
 [Route("content")]
 public class ContentController : ControllerBase
 {
+    // 匿名接口：不需要 token，适合验证 API 是否活着。
     [HttpGet("public")]
     [AllowAnonymous]
     public IActionResult Public()
         => Ok("Public content");
 
+    // 基础认证接口：只要 token 有效即可，不检查 role/scope。
     [HttpGet("user")]
     [Authorize]
     public IActionResult UserContent()
         => Ok("User or authenticated service content");
 
+    // 角色授权：要求 token 里有 role=Admin。
     [HttpGet("admin")]
     [Authorize(Roles = "Admin")]
     public IActionResult AdminContent()
         => Ok("Admin content");
 
+    // scope 授权：要求 token 里包含 content.read。
     [HttpGet("read")]
     [Authorize(Policy = "ContentRead")]
     public IActionResult ReadContent()
         => Ok("Content read allowed");
 
+    // 更细粒度的写权限：普通 user 没有 content.write，会得到 403。
     [HttpPost("write")]
     [Authorize(Policy = "ContentWrite")]
     public IActionResult WriteContent()
         => Ok("Content write allowed");
 
+    // 服务调用授权：要求 token_type=service，用户 token 不能访问。
     [HttpGet("service")]
     [Authorize(Policy = "ServiceOnly")]
     public IActionResult ServiceContent()

--- a/backend/AuthFlowLab.ApiServer/Program.cs
+++ b/backend/AuthFlowLab.ApiServer/Program.cs
@@ -7,6 +7,8 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
+
+// 生成 OpenAPI JSON 和 Swagger UI，并声明受保护接口需要 Bearer JWT。
 builder.Services.AddSwaggerGen(options =>
 {
     options.SwaggerDoc("v1", new OpenApiInfo
@@ -34,6 +36,8 @@ builder.Services.AddSwaggerGen(options =>
     });
 });
 
+// Authentication：验证 Bearer token 的签名、issuer、audience 和过期时间。
+// 这里使用 Authority，JwtBearer 会读取 AuthServer 的 discovery document 和 JWKS 公钥。
 builder.Services
     .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
@@ -52,8 +56,10 @@ builder.Services
         };
     });
 
+// Authorization：token 已可信后，根据 claims 判断能不能访问具体资源。
 builder.Services.AddAuthorization(options =>
 {
+    // content.read 使用 OAuth2 scope claim 控制，多个 scope 用空格分隔。
     options.AddPolicy("ContentRead", policy => policy.RequireAssertion(context =>
     {
         return context.User.FindAll("scope")
@@ -61,6 +67,7 @@ builder.Services.AddAuthorization(options =>
             .Contains("content.read", StringComparer.Ordinal);
     }));
 
+    // content.write 是更细粒度的写权限，用于验证 read/write scope 的差异。
     options.AddPolicy("ContentWrite", policy => policy.RequireAssertion(context =>
     {
         return context.User.FindAll("scope")
@@ -68,6 +75,7 @@ builder.Services.AddAuthorization(options =>
             .Contains("content.write", StringComparer.Ordinal);
     }));
 
+    // ServiceOnly 通过自定义 token_type claim 区分 service token 和 user token。
     options.AddPolicy("ServiceOnly", policy => policy.RequireAssertion(context =>
     {
         return context.User.HasClaim(c => c.Type == "token_type" && c.Value == "service");
@@ -76,10 +84,13 @@ builder.Services.AddAuthorization(options =>
 
 var app = builder.Build();
 
+// Swagger UI 读取 /swagger/v1/swagger.json，提供浏览器里的 API 调试界面。
 app.UseSwagger();
 app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
+
+// 中间件顺序很重要：先 Authentication 解析并验证 token，再 Authorization 执行策略。
 app.UseAuthentication();
 app.UseAuthorization();
 
@@ -87,4 +98,5 @@ app.MapControllers();
 
 app.Run();
 
+// WebApplicationFactory 集成测试需要可引用的 Program 类型。
 public partial class Program;

--- a/backend/AuthFlowLab.AuthServer/AuthFlowLab.AuthServer.http
+++ b/backend/AuthFlowLab.AuthServer/AuthFlowLab.AuthServer.http
@@ -9,6 +9,7 @@ GET {{AuthServer}}/.well-known/jwks.json
 Accept: application/json
 
 ### Login as a normal user
+# 用户登录：返回 user token，scope 只有 content.read。
 # @name userLogin
 POST {{AuthServer}}/auth/login
 Content-Type: application/json
@@ -20,6 +21,7 @@ Accept: application/json
 }
 
 ### Login as admin
+# 管理员登录：返回 user token，role=Admin，scope 包含 content.write。
 # @name adminLogin
 POST {{AuthServer}}/auth/login
 Content-Type: application/json
@@ -31,6 +33,7 @@ Accept: application/json
 }
 
 ### Issue a service token with client_credentials
+# OAuth2 token endpoint：使用 form-urlencoded 的 client_credentials 换 service token。
 # @name clientToken
 POST {{AuthServer}}/connect/token
 Content-Type: application/x-www-form-urlencoded
@@ -42,6 +45,7 @@ grant_type=client_credentials
 &scope=content.read content.write
 
 ### Invalid login returns an OAuth-style error
+# 认证失败示例：用户名密码错误返回 invalid_grant。
 POST {{AuthServer}}/auth/login
 Content-Type: application/json
 Accept: application/json

--- a/backend/AuthFlowLab.AuthServer/Controllers/AuthController.cs
+++ b/backend/AuthFlowLab.AuthServer/Controllers/AuthController.cs
@@ -22,16 +22,19 @@ public class AuthController : ControllerBase
     [HttpPost("login")]
     public IActionResult Login(LoginRequest request)
     {
+        // 认证阶段：校验用户提交的 username/password，确认调用方是谁。
         var user = _authOptions.Users.FirstOrDefault(user =>
             user.Username == request.Username && user.Password == request.Password);
 
         if (user is null)
         {
+            // 用户名或密码错误属于认证失败，返回 401 + OAuth 风格错误码。
             return Unauthorized(new AuthErrorResponse(
                 "invalid_grant",
                 "The username or password is invalid."));
         }
 
+        // 登录成功后，AuthServer 根据配置中的 role/scope 生成用户 access token。
         return Ok(_jwtService.GenerateUserToken(user.Username, user.Role, user.Scopes));
     }
 

--- a/backend/AuthFlowLab.AuthServer/Controllers/ConnectController.cs
+++ b/backend/AuthFlowLab.AuthServer/Controllers/ConnectController.cs
@@ -29,6 +29,7 @@ public class ConnectController : ControllerBase
         [FromForm(Name = "client_secret")] string? clientSecret,
         [FromForm(Name = "scope")] string? scope)
     {
+        // OAuth2 token endpoint 必须通过 grant_type 指明“用哪种方式换 token”。
         if (string.IsNullOrWhiteSpace(grantType))
         {
             return BadRequest(new AuthErrorResponse(
@@ -36,6 +37,7 @@ public class ConnectController : ControllerBase
                 "The grant_type form field is required."));
         }
 
+        // 当前阶段只实现 client_credentials；authorization_code + PKCE 后续再加。
         if (grantType != ClientCredentialsGrantType)
         {
             return BadRequest(new AuthErrorResponse(
@@ -43,16 +45,19 @@ public class ConnectController : ControllerBase
                 "Only client_credentials is supported by this token endpoint."));
         }
 
+        // client_credentials 认证的是“系统/服务客户端”，不是最终用户。
         var client = _authOptions.Clients.FirstOrDefault(client =>
             client.ClientId == clientId && client.ClientSecret == clientSecret);
 
         if (client is null)
         {
+            // client_id 或 client_secret 错误属于客户端认证失败。
             return Unauthorized(new AuthErrorResponse(
                 "invalid_client",
                 "The client id or secret is invalid."));
         }
 
+        // 同一个 client 未来可能允许不同 grant type，这里先校验它是否允许 client_credentials。
         if (!client.AllowedGrantTypes.Contains(ClientCredentialsGrantType, StringComparer.Ordinal))
         {
             return BadRequest(new AuthErrorResponse(
@@ -60,10 +65,12 @@ public class ConnectController : ControllerBase
                 "The client is not allowed to use the requested grant type."));
         }
 
+        // scope 是客户端申请访问 API 的权限范围；未传时使用该 client 默认允许的全部 scope。
         var requestedScopes = string.IsNullOrWhiteSpace(scope)
             ? client.Scopes
             : scope.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
 
+        // AuthServer 必须拒绝 client 配置中没有预先允许的 scope。
         if (requestedScopes.Any(requestedScope => !client.Scopes.Contains(requestedScope, StringComparer.Ordinal)))
         {
             return BadRequest(new AuthErrorResponse(
@@ -71,6 +78,7 @@ public class ConnectController : ControllerBase
                 "The requested scope is not allowed for this client."));
         }
 
+        // 认证和授权范围校验都通过后，签发 service token 给系统调用 API。
         return Ok(_jwtService.GenerateServiceToken(client.ClientId, requestedScopes));
     }
 }

--- a/backend/AuthFlowLab.AuthServer/Models/AuthErrorResponse.cs
+++ b/backend/AuthFlowLab.AuthServer/Models/AuthErrorResponse.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace AuthFlowLab.AuthServer.Models;
 
+// OAuth2 风格错误响应，便于前端和测试根据 error code 做稳定判断。
 public sealed record AuthErrorResponse(
     [property: JsonPropertyName("error")] string Error,
     [property: JsonPropertyName("error_description")] string ErrorDescription);

--- a/backend/AuthFlowLab.AuthServer/Models/TokenResponse.cs
+++ b/backend/AuthFlowLab.AuthServer/Models/TokenResponse.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace AuthFlowLab.AuthServer.Models;
 
+// OAuth2 token endpoint 的标准响应形状；JSON 字段名使用 snake_case。
 public sealed record TokenResponse(
     [property: JsonPropertyName("access_token")] string AccessToken,
     [property: JsonPropertyName("token_type")] string TokenType,

--- a/backend/AuthFlowLab.AuthServer/Options/AuthOptions.cs
+++ b/backend/AuthFlowLab.AuthServer/Options/AuthOptions.cs
@@ -2,10 +2,13 @@ namespace AuthFlowLab.AuthServer.Options;
 
 public sealed class AuthOptions
 {
+    // access_token 有效期，单位是分钟；JwtService 会转换成 expires_in 秒数返回。
     public int AccessTokenMinutes { get; init; } = 30;
 
+    // 实验阶段使用配置文件模拟用户库；真实系统通常来自数据库或 ASP.NET Core Identity。
     public List<AuthUser> Users { get; init; } = [];
 
+    // OAuth2 client 注册表；每个 client 预先声明 grant type 和允许申请的 scope。
     public List<AuthClient> Clients { get; init; } = [];
 }
 
@@ -24,9 +27,12 @@ public sealed class AuthClient
 {
     public string ClientId { get; init; } = "";
 
+    // 实验用明文 secret；真实系统应存储哈希或放在安全密钥系统中。
     public string ClientSecret { get; init; } = "";
 
+    // 控制该 client 能用哪些 OAuth2 授权方式换 token。
     public List<string> AllowedGrantTypes { get; init; } = [];
 
+    // 控制该 client 最多能申请哪些 API 访问范围。
     public List<string> Scopes { get; init; } = [];
 }

--- a/backend/AuthFlowLab.AuthServer/Program.cs
+++ b/backend/AuthFlowLab.AuthServer/Program.cs
@@ -3,23 +3,32 @@ using AuthFlowLab.AuthServer.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// 注册 Controller 和 Swagger，方便本地查看 AuthServer 的实验接口。
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+// AuthOptions 对应 appsettings.json 的 Auth 节点，集中保存用户、客户端、scope 和 token 过期时间。
 builder.Services.Configure<AuthOptions>(builder.Configuration.GetSection("Auth"));
+
+// RsaKeyService 统一管理私钥读取、JWT 签名凭证和 JWKS 公钥导出。
 builder.Services.AddSingleton<RsaKeyService>();
+
+// JwtService 负责把用户/client 信息转换成 claims，并生成 OAuth2 风格 token response。
 builder.Services.AddSingleton<JwtService>();
 
 var app = builder.Build();
 
+// AuthServer 的 Swagger 主要用于调试登录、token endpoint、discovery 和 JWKS。
 app.UseSwagger();
 app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
 
+// 映射 /auth/login、/connect/token 和 /.well-known/* 等 Controller 路由。
 app.MapControllers();
 
 app.Run();
 
+// WebApplicationFactory 集成测试需要可引用的 Program 类型。
 public partial class Program;

--- a/backend/AuthFlowLab.AuthServer/Services/JwtService.cs
+++ b/backend/AuthFlowLab.AuthServer/Services/JwtService.cs
@@ -25,15 +25,21 @@ public class JwtService
 
     public TokenResponse GenerateUserToken(string username, string role, IEnumerable<string> scopes)
     {
+        // OAuth2 常见做法是把多个 scope 放在同一个 claim 中，用空格分隔。
         var scope = string.Join(' ', scopes);
         var claims = new List<Claim>
         {
+            // sub 表示 token 的主体；用户 token 中就是用户名。
             new(JwtRegisteredClaimNames.Sub, username),
+            // jti 是 token 唯一 ID，后续做撤销、审计或重放防护时会用到。
             new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N")),
+            // iat 表示签发时间，使用 Unix epoch 秒。
             new(JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(DateTime.UtcNow).ToString(), ClaimValueTypes.Integer64),
             new(ClaimTypes.Name, username),
+            // role 是 ASP.NET Core [Authorize(Roles = "...")] 能直接识别的角色 claim。
             new(ClaimTypes.Role, role),
             new("scope", scope),
+            // token_type 是本实验自定义 claim，用来区分 user token 和 service token。
             new("token_type", "user")
         };
 
@@ -45,6 +51,7 @@ public class JwtService
         var scope = string.Join(' ', scopes);
         var claims = new List<Claim>
         {
+            // service token 的主体是 client_id，而不是用户。
             new(JwtRegisteredClaimNames.Sub, clientId),
             new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N")),
             new(JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(DateTime.UtcNow).ToString(), ClaimValueTypes.Integer64),
@@ -58,11 +65,15 @@ public class JwtService
 
     private TokenResponse GenerateToken(List<Claim> claims, string scope)
     {
-        var issuer = _configuration["Jwt:Issuer"] ?? "auth-flow-lab";
+        // issuer/audience 是 ApiServer 验证 token 时必须匹配的信任边界。
+        var issuer = _configuration["Jwt:Issuer"] ?? "http://127.0.0.1:5001";
         var audience = _configuration["Jwt:Audience"] ?? "api-server";
         var expiresIn = _authOptions.AccessTokenMinutes * 60;
+
+        // RS256 = RSA 私钥签名 + SHA-256；签名凭证由 RsaKeyService 统一创建。
         var credentials = _rsaKeyService.CreateSigningCredentials();
 
+        // payload 中放 claims，signature 由私钥生成；ApiServer 后续通过 JWKS 公钥验证 signature。
         var token = new JwtSecurityToken(
             issuer: issuer,
             audience: audience,
@@ -71,6 +82,7 @@ public class JwtService
             signingCredentials: credentials
         );
 
+        // 返回 OAuth2 风格 token response，access_token 才是调用 API 时放到 Authorization header 的值。
         return new TokenResponse(
             new JwtSecurityTokenHandler().WriteToken(token),
             "Bearer",

--- a/backend/AuthFlowLab.http
+++ b/backend/AuthFlowLab.http
@@ -2,6 +2,7 @@
 @ApiServer = http://127.0.0.1:5002
 
 ### User login
+# 用户认证：AuthServer 校验用户名密码，成功后用私钥签发 user token。
 # @name userLogin
 POST {{AuthServer}}/auth/login
 Content-Type: application/json
@@ -13,21 +14,25 @@ Accept: application/json
 }
 
 ### User token can access authenticated content
+# 基础认证：只要 Bearer token 有效就可以访问。
 GET {{ApiServer}}/content/user
 Accept: application/json
 Authorization: Bearer {{userLogin.response.body.$.access_token}}
 
 ### User token can access content.read policy
+# scope 授权：user token 里包含 content.read。
 GET {{ApiServer}}/content/read
 Accept: application/json
 Authorization: Bearer {{userLogin.response.body.$.access_token}}
 
 ### Normal user cannot access content.write policy
+# 权限不足示例：user token 没有 content.write，预期返回 403。
 POST {{ApiServer}}/content/write
 Accept: application/json
 Authorization: Bearer {{userLogin.response.body.$.access_token}}
 
 ### Admin login
+# 角色示例：admin token 会带 role=Admin 和 content.write scope。
 # @name adminLogin
 POST {{AuthServer}}/auth/login
 Content-Type: application/json
@@ -39,16 +44,19 @@ Accept: application/json
 }
 
 ### Admin token can access admin content
+# 角色授权：ApiServer 检查 role=Admin。
 GET {{ApiServer}}/content/admin
 Accept: application/json
 Authorization: Bearer {{adminLogin.response.body.$.access_token}}
 
 ### Admin token can access content.write policy
+# 写权限授权：ApiServer 检查 scope 是否包含 content.write。
 POST {{ApiServer}}/content/write
 Accept: application/json
 Authorization: Bearer {{adminLogin.response.body.$.access_token}}
 
 ### Client credentials-style service token
+# OAuth2 client_credentials：系统用 client_id/client_secret 换 service token。
 # @name serviceToken
 POST {{AuthServer}}/connect/token
 Content-Type: application/x-www-form-urlencoded
@@ -60,16 +68,19 @@ grant_type=client_credentials
 &scope=content.read content.write
 
 ### Service token can access service-only content
+# 服务调用授权：ApiServer 检查 token_type=service。
 GET {{ApiServer}}/content/service
 Accept: application/json
 Authorization: Bearer {{serviceToken.response.body.$.access_token}}
 
 ### Service token can also access content.read
+# service token 也可以按 scope 访问普通资源。
 GET {{ApiServer}}/content/read
 Accept: application/json
 Authorization: Bearer {{serviceToken.response.body.$.access_token}}
 
 ### Service token can also access content.write
+# service token 拥有 content.write，所以可以访问写接口。
 POST {{ApiServer}}/content/write
 Accept: application/json
 Authorization: Bearer {{serviceToken.response.body.$.access_token}}


### PR DESCRIPTION
## Summary
- add Chinese comments around AuthServer login, client_credentials, JWT signing, and options configuration
- add Chinese comments around ApiServer JWT validation, authorization policies, and protected content endpoints
- add Chinese notes to `.http` examples for the main learning flow

## Verification
- `dotnet test backend\AuthFlowLab.sln`