### PR TITLE
Add discovery and JWKS endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A minimal authentication and authorization lab for learning JWT bearer validatio
 ## Current Scope
 
 - User login issues JWT access tokens.
-- Client credentials-style service token issuing is available through a simplified JSON endpoint.
+- Client credentials uses the OAuth2-style `/connect/token` endpoint.
+- Auth Server exposes OpenID Connect discovery metadata and JWKS.
 - API Server validates JWTs signed by Auth Server.
 - API endpoints demonstrate anonymous, authenticated, role, scope, and service-only authorization.
 
@@ -16,7 +17,8 @@ Frontend -> Auth Server -> API -> Database
 For the current lab stage:
 
 - Auth Server signs JWTs with `keys/private.key`.
-- API Server validates JWT signatures with `keys/public.key`.
+- Auth Server exposes its public signing key through JWKS.
+- API Server uses `Jwt:Authority` to load discovery metadata and JWKS automatically.
 - User accounts, client credentials, allowed scopes, and token lifetime are configured in `AuthFlowLab.AuthServer/appsettings.json`.
 
 ## Run Locally
@@ -66,7 +68,7 @@ Response:
   "access_token": "<jwt>",
   "token_type": "Bearer",
   "expires_in": 1800,
-  "scope": "content.read content.write"
+  "scope": "content.read"
 }
 ```
 
@@ -94,6 +96,20 @@ grant_type=client_credentials
 The response shape is the same as login. Invalid clients return `invalid_client`; unsupported grant types return `unsupported_grant_type`; disallowed scopes return `invalid_scope`.
 
 The old lab-only `/auth/client-token` endpoint has been removed. Service tokens now use the OAuth2-style `/connect/token` endpoint.
+
+### Discovery And JWKS
+
+```http
+GET http://127.0.0.1:5001/.well-known/openid-configuration
+```
+
+The discovery document includes the issuer, token endpoint, JWKS URI, supported grant types, and supported scopes.
+
+```http
+GET http://127.0.0.1:5001/.well-known/jwks.json
+```
+
+The JWKS document exposes the RSA public key used by API servers to verify JWT signatures.
 
 ## API Server Endpoints
 

--- a/backend/AuthFlowLab.ApiServer.Tests/ContentEndpointTests.cs
+++ b/backend/AuthFlowLab.ApiServer.Tests/ContentEndpointTests.cs
@@ -4,8 +4,12 @@ using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 
 namespace AuthFlowLab.ApiServer.Tests;
@@ -113,13 +117,9 @@ public sealed class ContentEndpointTests : IClassFixture<ApiServerFactory>
 public sealed class ApiServerFactory : WebApplicationFactory<Program>
 {
     private readonly RSA _rsa = RSA.Create(2048);
-    private readonly string _publicKeyPath;
 
     public ApiServerFactory()
     {
-        _publicKeyPath = Path.Combine(Path.GetTempPath(), $"auth-flow-lab-test-{Guid.NewGuid():N}.key");
-        File.WriteAllText(_publicKeyPath, _rsa.ExportRSAPublicKeyPem());
-        Environment.SetEnvironmentVariable("Jwt__PublicKeyPath", _publicKeyPath);
     }
 
     public string CreateToken(string subject, string tokenType, string? role = null, string? scope = null)
@@ -141,11 +141,14 @@ public sealed class ApiServerFactory : WebApplicationFactory<Program>
         }
 
         var token = new JwtSecurityToken(
-            issuer: "auth-flow-lab",
+            issuer: "http://auth-flow-lab.test",
             audience: "api-server",
             claims: claims,
             expires: DateTime.UtcNow.AddMinutes(10),
-            signingCredentials: new SigningCredentials(new RsaSecurityKey(_rsa), SecurityAlgorithms.RsaSha256));
+            signingCredentials: new SigningCredentials(new RsaSecurityKey(_rsa)
+            {
+                KeyId = "test-key"
+            }, SecurityAlgorithms.RsaSha256));
 
         return new JwtSecurityTokenHandler().WriteToken(token);
     }
@@ -157,7 +160,29 @@ public sealed class ApiServerFactory : WebApplicationFactory<Program>
         {
             config.AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Jwt:PublicKeyPath"] = _publicKeyPath
+                ["Jwt:Authority"] = "http://auth-flow-lab.test",
+                ["Jwt:Audience"] = "api-server",
+                ["Jwt:RequireHttpsMetadata"] = "false"
+            });
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            services.PostConfigure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
+            {
+                var signingKey = new RsaSecurityKey(_rsa)
+                {
+                    KeyId = "test-key"
+                };
+
+                options.Configuration = new OpenIdConnectConfiguration
+                {
+                    Issuer = "http://auth-flow-lab.test"
+                };
+
+                options.Configuration.SigningKeys.Add(signingKey);
+                options.TokenValidationParameters.IssuerSigningKey = signingKey;
+                options.TokenValidationParameters.TryAllIssuerSigningKeys = true;
             });
         });
     }

--- a/backend/AuthFlowLab.ApiServer/Program.cs
+++ b/backend/AuthFlowLab.ApiServer/Program.cs
@@ -1,5 +1,4 @@
 using System.Security.Claims;
-using System.Security.Cryptography;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.OpenApi;
 using Microsoft.IdentityModel.Tokens;
@@ -35,30 +34,20 @@ builder.Services.AddSwaggerGen(options =>
     });
 });
 
-var publicKeyPath = builder.Configuration["Jwt:PublicKeyPath"] ?? "../../keys/public.key";
-publicKeyPath = Path.IsPathRooted(publicKeyPath)
-    ? publicKeyPath
-    : Path.GetFullPath(publicKeyPath, builder.Environment.ContentRootPath);
-
-var publicKey = File.ReadAllText(publicKeyPath);
-var rsa = RSA.Create();
-rsa.ImportFromPem(publicKey);
-var signingKey = new RsaSecurityKey(rsa);
-
 builder.Services
     .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
+        options.Authority = builder.Configuration["Jwt:Authority"] ?? "http://127.0.0.1:5001";
+        options.Audience = builder.Configuration["Jwt:Audience"] ?? "api-server";
+        options.RequireHttpsMetadata = builder.Configuration.GetValue("Jwt:RequireHttpsMetadata", false);
         options.TokenValidationParameters = new TokenValidationParameters
         {
             ValidateIssuer = true,
-            ValidIssuer = builder.Configuration["Jwt:Issuer"] ?? "auth-flow-lab",
+            ValidIssuer = (builder.Configuration["Jwt:Authority"] ?? "http://127.0.0.1:5001").TrimEnd('/'),
             ValidateAudience = true,
-            ValidAudience = builder.Configuration["Jwt:Audience"] ?? "api-server",
             ValidateLifetime = true,
             ValidateIssuerSigningKey = true,
-            IssuerSigningKey = signingKey,
-            TryAllIssuerSigningKeys = true,
             RoleClaimType = ClaimTypes.Role
         };
     });

--- a/backend/AuthFlowLab.ApiServer/appsettings.Development.json
+++ b/backend/AuthFlowLab.ApiServer/appsettings.Development.json
@@ -4,5 +4,10 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Jwt": {
+    "Authority": "http://127.0.0.1:5001",
+    "Audience": "api-server",
+    "RequireHttpsMetadata": false
   }
 }

--- a/backend/AuthFlowLab.ApiServer/appsettings.json
+++ b/backend/AuthFlowLab.ApiServer/appsettings.json
@@ -6,9 +6,9 @@
     }
   },
   "Jwt": {
-    "Issuer": "auth-flow-lab",
+    "Authority": "http://127.0.0.1:5001",
     "Audience": "api-server",
-    "PublicKeyPath": "../../keys/public.key"
+    "RequireHttpsMetadata": false
   },
   "AllowedHosts": "*"
 }

--- a/backend/AuthFlowLab.AuthServer.Tests/AuthEndpointTests.cs
+++ b/backend/AuthFlowLab.AuthServer.Tests/AuthEndpointTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Security.Cryptography;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Hosting;
@@ -131,6 +132,30 @@ public sealed class AuthEndpointTests : IClassFixture<AuthServerFactory>
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
+
+    [Fact]
+    public async Task Discovery_ReturnsMetadataForClientCredentials()
+    {
+        var document = await _client.GetFromJsonAsync<JsonElement>("/.well-known/openid-configuration");
+
+        Assert.Equal("http://auth-flow-lab.test", document.GetProperty("issuer").GetString());
+        Assert.Equal("http://auth-flow-lab.test/connect/token", document.GetProperty("token_endpoint").GetString());
+        Assert.Equal("http://auth-flow-lab.test/.well-known/jwks.json", document.GetProperty("jwks_uri").GetString());
+        Assert.Contains("client_credentials", document.GetProperty("grant_types_supported").EnumerateArray().Select(item => item.GetString()));
+    }
+
+    [Fact]
+    public async Task Jwks_ReturnsPublicSigningKey()
+    {
+        var document = await _client.GetFromJsonAsync<JsonElement>("/.well-known/jwks.json");
+        var key = document.GetProperty("keys").EnumerateArray().Single();
+
+        Assert.Equal("auth-flow-lab-test-key", key.GetProperty("kid").GetString());
+        Assert.Equal("RSA", key.GetProperty("kty").GetString());
+        Assert.Equal("RS256", key.GetProperty("alg").GetString());
+        Assert.False(string.IsNullOrWhiteSpace(key.GetProperty("n").GetString()));
+        Assert.False(string.IsNullOrWhiteSpace(key.GetProperty("e").GetString()));
+    }
 }
 
 public sealed class AuthServerFactory : WebApplicationFactory<Program>
@@ -152,6 +177,8 @@ public sealed class AuthServerFactory : WebApplicationFactory<Program>
             config.AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["Jwt:PrivateKeyPath"] = _privateKeyPath,
+                ["Jwt:Issuer"] = "http://auth-flow-lab.test",
+                ["Jwt:KeyId"] = "auth-flow-lab-test-key",
                 ["Auth:AccessTokenMinutes"] = "10",
                 ["Auth:Users:0:Username"] = "test-admin",
                 ["Auth:Users:0:Password"] = "admin123",

--- a/backend/AuthFlowLab.AuthServer/AuthFlowLab.AuthServer.http
+++ b/backend/AuthFlowLab.AuthServer/AuthFlowLab.AuthServer.http
@@ -1,5 +1,13 @@
 @AuthServer = http://127.0.0.1:5001
 
+### Discovery metadata
+GET {{AuthServer}}/.well-known/openid-configuration
+Accept: application/json
+
+### JWKS public signing keys
+GET {{AuthServer}}/.well-known/jwks.json
+Accept: application/json
+
 ### Login as a normal user
 # @name userLogin
 POST {{AuthServer}}/auth/login

--- a/backend/AuthFlowLab.AuthServer/Controllers/DiscoveryController.cs
+++ b/backend/AuthFlowLab.AuthServer/Controllers/DiscoveryController.cs
@@ -1,0 +1,51 @@
+using AuthFlowLab.AuthServer.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AuthFlowLab.AuthServer.Controllers;
+
+[ApiController]
+[Route(".well-known")]
+public sealed class DiscoveryController : ControllerBase
+{
+    private readonly IConfiguration _configuration;
+    private readonly RsaKeyService _rsaKeyService;
+
+    public DiscoveryController(IConfiguration configuration, RsaKeyService rsaKeyService)
+    {
+        _configuration = configuration;
+        _rsaKeyService = rsaKeyService;
+    }
+
+    [HttpGet("openid-configuration")]
+    public IActionResult OpenIdConfiguration()
+    {
+        var issuer = GetIssuer();
+
+        return Ok(new
+        {
+            issuer,
+            token_endpoint = $"{issuer}/connect/token",
+            jwks_uri = $"{issuer}/.well-known/jwks.json",
+            response_types_supported = Array.Empty<string>(),
+            grant_types_supported = new[] { "client_credentials" },
+            token_endpoint_auth_methods_supported = new[] { "client_secret_post" },
+            scopes_supported = new[] { "content.read", "content.write" },
+            claims_supported = new[] { "sub", "client_id", "scope", "token_type", "role", "name" },
+            id_token_signing_alg_values_supported = new[] { "RS256" }
+        });
+    }
+
+    [HttpGet("jwks.json")]
+    public IActionResult Jwks()
+    {
+        return Ok(new
+        {
+            keys = new[] { _rsaKeyService.CreateJsonWebKey() }
+        });
+    }
+
+    private string GetIssuer()
+    {
+        return (_configuration["Jwt:Issuer"] ?? $"{Request.Scheme}://{Request.Host}").TrimEnd('/');
+    }
+}

--- a/backend/AuthFlowLab.AuthServer/Program.cs
+++ b/backend/AuthFlowLab.AuthServer/Program.cs
@@ -8,6 +8,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 builder.Services.Configure<AuthOptions>(builder.Configuration.GetSection("Auth"));
+builder.Services.AddSingleton<RsaKeyService>();
 builder.Services.AddSingleton<JwtService>();
 
 var app = builder.Build();

--- a/backend/AuthFlowLab.AuthServer/Services/JwtService.cs
+++ b/backend/AuthFlowLab.AuthServer/Services/JwtService.cs
@@ -1,9 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
-using System.Security.Cryptography;
 using AuthFlowLab.AuthServer.Models;
 using AuthFlowLab.AuthServer.Options;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 
@@ -12,17 +10,17 @@ namespace AuthFlowLab.AuthServer.Services;
 public class JwtService
 {
     private readonly IConfiguration _configuration;
-    private readonly IWebHostEnvironment _environment;
     private readonly AuthOptions _authOptions;
+    private readonly RsaKeyService _rsaKeyService;
 
     public JwtService(
         IConfiguration configuration,
-        IWebHostEnvironment environment,
-        IOptions<AuthOptions> authOptions)
+        IOptions<AuthOptions> authOptions,
+        RsaKeyService rsaKeyService)
     {
         _configuration = configuration;
-        _environment = environment;
         _authOptions = authOptions.Value;
+        _rsaKeyService = rsaKeyService;
     }
 
     public TokenResponse GenerateUserToken(string username, string role, IEnumerable<string> scopes)
@@ -63,20 +61,7 @@ public class JwtService
         var issuer = _configuration["Jwt:Issuer"] ?? "auth-flow-lab";
         var audience = _configuration["Jwt:Audience"] ?? "api-server";
         var expiresIn = _authOptions.AccessTokenMinutes * 60;
-        var privateKeyPath = _configuration["Jwt:PrivateKeyPath"]
-            ?? throw new InvalidOperationException("Private key path is missing.");
-
-        privateKeyPath = Path.IsPathRooted(privateKeyPath)
-            ? privateKeyPath
-            : Path.GetFullPath(privateKeyPath, _environment.ContentRootPath);
-
-        var privateKey = File.ReadAllText(privateKeyPath);
-
-        var rsa = RSA.Create();
-        rsa.ImportFromPem(privateKey);
-
-        var signingKey = new RsaSecurityKey(rsa);
-        var credentials = new SigningCredentials(signingKey, SecurityAlgorithms.RsaSha256);
+        var credentials = _rsaKeyService.CreateSigningCredentials();
 
         var token = new JwtSecurityToken(
             issuer: issuer,

--- a/backend/AuthFlowLab.AuthServer/Services/RsaKeyService.cs
+++ b/backend/AuthFlowLab.AuthServer/Services/RsaKeyService.cs
@@ -1,0 +1,62 @@
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.IdentityModel.Tokens;
+
+namespace AuthFlowLab.AuthServer.Services;
+
+public sealed class RsaKeyService
+{
+    private readonly IConfiguration _configuration;
+    private readonly IWebHostEnvironment _environment;
+    private readonly Lazy<RSA> _rsa;
+
+    public RsaKeyService(IConfiguration configuration, IWebHostEnvironment environment)
+    {
+        _configuration = configuration;
+        _environment = environment;
+        _rsa = new Lazy<RSA>(LoadPrivateKey);
+    }
+
+    public string KeyId => _configuration["Jwt:KeyId"] ?? "auth-flow-lab-key-1";
+
+    public SigningCredentials CreateSigningCredentials()
+    {
+        var signingKey = new RsaSecurityKey(_rsa.Value)
+        {
+            KeyId = KeyId
+        };
+
+        return new SigningCredentials(signingKey, SecurityAlgorithms.RsaSha256);
+    }
+
+    public JsonWebKey CreateJsonWebKey()
+    {
+        var parameters = _rsa.Value.ExportParameters(includePrivateParameters: false);
+
+        return new JsonWebKey
+        {
+            Kty = JsonWebAlgorithmsKeyTypes.RSA,
+            Use = "sig",
+            Kid = KeyId,
+            Alg = SecurityAlgorithms.RsaSha256,
+            N = Base64UrlEncoder.Encode(parameters.Modulus),
+            E = Base64UrlEncoder.Encode(parameters.Exponent)
+        };
+    }
+
+    private RSA LoadPrivateKey()
+    {
+        var privateKeyPath = _configuration["Jwt:PrivateKeyPath"]
+            ?? throw new InvalidOperationException("Private key path is missing.");
+
+        privateKeyPath = Path.IsPathRooted(privateKeyPath)
+            ? privateKeyPath
+            : Path.GetFullPath(privateKeyPath, _environment.ContentRootPath);
+
+        var privateKey = File.ReadAllText(privateKeyPath);
+
+        var rsa = RSA.Create();
+        rsa.ImportFromPem(privateKey);
+        return rsa;
+    }
+}

--- a/backend/AuthFlowLab.AuthServer/appsettings.Development.json
+++ b/backend/AuthFlowLab.AuthServer/appsettings.Development.json
@@ -6,8 +6,9 @@
     }
   },
   "Jwt": {
-    "Issuer": "auth-flow-lab",
+    "Issuer": "http://127.0.0.1:5001",
     "Audience": "api-server",
+    "KeyId": "auth-flow-lab-key-1",
     "PrivateKeyPath": "../../keys/private.key"
   },
   "Auth": {

--- a/backend/AuthFlowLab.AuthServer/appsettings.json
+++ b/backend/AuthFlowLab.AuthServer/appsettings.json
@@ -6,8 +6,9 @@
     }
   },
   "Jwt": {
-    "Issuer": "auth-flow-lab",
+    "Issuer": "http://127.0.0.1:5001",
     "Audience": "api-server",
+    "KeyId": "auth-flow-lab-key-1",
     "PrivateKeyPath": "../../keys/private.key"
   },
   "Auth": {


### PR DESCRIPTION
## Summary
- add OpenID Connect discovery metadata at `/.well-known/openid-configuration`
- add JWKS public signing key endpoint at `/.well-known/jwks.json`
- factor RSA key loading/signing/JWKS export into `RsaKeyService`
- switch ApiServer from manual `PublicKeyPath` validation to `Authority` + `Audience`
- update docs, HTTP examples, and integration tests

## Verification
- `dotnet test backend\AuthFlowLab.sln`