### PR TITLE
Move PKCE login to Auth Server cookie flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The old lab-only `/auth/client-token` endpoint has been removed. Service tokens 
 
 ### Authorization Code + PKCE And OIDC
 
-The current lab version simulates the login page by accepting `username` and `password` on the authorize request. A real frontend will replace that with a browser login screen.
+The SPA starts the authorization request without sending a password. If the user is not signed in, Auth Server shows its own login page, creates an HTTP-only login cookie, and then redirects back to the original authorize request.
 
 When the request includes `openid`, Auth Server also returns an OIDC `id_token`. The `access_token` is for API access; the `id_token` is for the client application to know who logged in.
 
@@ -162,7 +162,7 @@ Start the authorization request:
 
 ```http
 # 中文注释: 发起授权码加 PKCE 的授权请求。
-GET http://127.0.0.1:5001/connect/authorize?response_type=code&client_id=demo-spa&redirect_uri=http%3A%2F%2F127.0.0.1%3A5173%2Fcallback&scope=openid%20profile%20content.read&state=demo-state&nonce=demo-nonce&code_challenge=mvtzfCbIJ5YDPp1UVYfCnz2ZSvRrCEUgWtyrhVS6xo8&code_challenge_method=S256&username=user&password=user123
+GET http://127.0.0.1:5001/connect/authorize?response_type=code&client_id=demo-spa&redirect_uri=http%3A%2F%2F127.0.0.1%3A5173%2Fcallback&scope=openid%20profile%20content.read&state=demo-state&nonce=demo-nonce&code_challenge=mvtzfCbIJ5YDPp1UVYfCnz2ZSvRrCEUgWtyrhVS6xo8&code_challenge_method=S256
 ```
 
 For this example:
@@ -286,7 +286,9 @@ npm run build
 2. Start API Server on `http://127.0.0.1:5002`.
 3. Start the Vite frontend on `http://127.0.0.1:5173`.
 4. Open the frontend and click `Login with PKCE`.
-5. Auth Server redirects back to `/callback` with an authorization code.
-6. The frontend exchanges the code for `access_token` and `id_token`.
-7. Click `Call API` to call `GET /content/read` with the access token.
-8. Click `UserInfo` to call `GET /connect/userinfo` with the access token.
+5. Auth Server shows its login page if there is no login cookie.
+6. Sign in with `user / user123` or `admin / admin123`.
+7. Auth Server redirects back to `/callback` with an authorization code.
+8. The frontend exchanges the code for `access_token` and `id_token`.
+9. Click `Call API` to call `GET /content/read` with the access token.
+10. Click `UserInfo` to call `GET /connect/userinfo` with the access token.

--- a/backend/AuthFlowLab.AuthServer.Tests/AuthEndpointTests.cs
+++ b/backend/AuthFlowLab.AuthServer.Tests/AuthEndpointTests.cs
@@ -170,6 +170,8 @@ public sealed class AuthEndpointTests : IClassFixture<AuthServerFactory>
     [Fact]
     public async Task Authorize_WithPkce_RedirectsWithCodeAndState()
     {
+        await SignInOnAuthServer();
+
         var verifier = "test-code-verifier-1234567890";
         var challenge = CreateS256Challenge(verifier);
         var authorizeUrl = QueryHelpers.AddQueryString("/connect/authorize", new Dictionary<string, string?>
@@ -181,9 +183,7 @@ public sealed class AuthEndpointTests : IClassFixture<AuthServerFactory>
             ["state"] = "abc-state",
             ["nonce"] = "abc-nonce",
             ["code_challenge"] = challenge,
-            ["code_challenge_method"] = "S256",
-            ["username"] = "test-user",
-            ["password"] = "user123"
+            ["code_challenge_method"] = "S256"
         });
 
         var response = await _client.GetAsync(authorizeUrl);
@@ -194,6 +194,31 @@ public sealed class AuthEndpointTests : IClassFixture<AuthServerFactory>
         var callbackQuery = QueryHelpers.ParseQuery(response.Headers.Location.Query);
         Assert.Equal("abc-state", callbackQuery["state"]);
         Assert.False(string.IsNullOrWhiteSpace(callbackQuery["code"]));
+    }
+
+    [Fact]
+    public async Task Authorize_WhenNotSignedIn_RedirectsToLoginPage()
+    {
+        var verifier = "test-code-verifier-1234567890";
+        var authorizeUrl = QueryHelpers.AddQueryString("/connect/authorize", new Dictionary<string, string?>
+        {
+            ["response_type"] = "code",
+            ["client_id"] = "demo-spa",
+            ["redirect_uri"] = "http://127.0.0.1:5173/callback",
+            ["scope"] = "openid profile content.read",
+            ["state"] = "login-state",
+            ["nonce"] = "login-nonce",
+            ["code_challenge"] = CreateS256Challenge(verifier),
+            ["code_challenge_method"] = "S256"
+        });
+
+        var response = await _client.GetAsync(authorizeUrl);
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.NotNull(response.Headers.Location);
+        var location = response.Headers.Location.ToString();
+        Assert.StartsWith("/account/login", location);
+        Assert.Contains("returnUrl=", location);
     }
 
     [Fact]
@@ -280,6 +305,8 @@ public sealed class AuthEndpointTests : IClassFixture<AuthServerFactory>
         string scope = "content.read",
         string? nonce = null)
     {
+        await SignInOnAuthServer();
+
         var authorizeUrl = QueryHelpers.AddQueryString("/connect/authorize", new Dictionary<string, string?>
         {
             ["response_type"] = "code",
@@ -289,9 +316,7 @@ public sealed class AuthEndpointTests : IClassFixture<AuthServerFactory>
             ["state"] = "token-test",
             ["nonce"] = nonce,
             ["code_challenge"] = CreateS256Challenge(verifier),
-            ["code_challenge_method"] = "S256",
-            ["username"] = "test-user",
-            ["password"] = "user123"
+            ["code_challenge_method"] = "S256"
         });
 
         var response = await _client.GetAsync(authorizeUrl);
@@ -299,6 +324,18 @@ public sealed class AuthEndpointTests : IClassFixture<AuthServerFactory>
 
         var callbackQuery = QueryHelpers.ParseQuery(response.Headers.Location!.Query);
         return callbackQuery["code"].ToString();
+    }
+
+    private async Task SignInOnAuthServer()
+    {
+        var response = await _client.PostAsync("/account/login", new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["username"] = "test-user",
+            ["password"] = "user123",
+            ["returnUrl"] = "/"
+        }));
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
     }
 
     private static string CreateS256Challenge(string verifier)

--- a/backend/AuthFlowLab.AuthServer/AuthFlowLab.AuthServer.http
+++ b/backend/AuthFlowLab.AuthServer/AuthFlowLab.AuthServer.http
@@ -42,10 +42,11 @@ Accept: application/json
 grant_type=client_credentials&client_id=worker-service&client_secret=worker-secret&scope=content.read%20content.write
 
 ### Start authorization_code + PKCE
-# Browser receives 302. Copy code from the Location callback URL.
+# Browser receives 302 to /account/login unless it already has the Auth Server login cookie.
+# After login, copy code from the Location callback URL.
 # code_verifier = demo-code-verifier-1234567890
 # code_challenge = SHA256(code_verifier) base64url
-GET {{AuthServer}}/connect/authorize?response_type=code&client_id=demo-spa&redirect_uri=http%3A%2F%2F127.0.0.1%3A5173%2Fcallback&scope=openid%20profile%20content.read&state=demo-state&nonce=demo-nonce&code_challenge=mvtzfCbIJ5YDPp1UVYfCnz2ZSvRrCEUgWtyrhVS6xo8&code_challenge_method=S256&username=user&password=user123
+GET {{AuthServer}}/connect/authorize?response_type=code&client_id=demo-spa&redirect_uri=http%3A%2F%2F127.0.0.1%3A5173%2Fcallback&scope=openid%20profile%20content.read&state=demo-state&nonce=demo-nonce&code_challenge=mvtzfCbIJ5YDPp1UVYfCnz2ZSvRrCEUgWtyrhVS6xo8&code_challenge_method=S256
 Accept: application/json
 
 ### Exchange authorization code for token

--- a/backend/AuthFlowLab.AuthServer/Controllers/AccountController.cs
+++ b/backend/AuthFlowLab.AuthServer/Controllers/AccountController.cs
@@ -1,0 +1,133 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using AuthFlowLab.AuthServer.Models;
+using AuthFlowLab.AuthServer.Options;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace AuthFlowLab.AuthServer.Controllers;
+
+[Route("account")]
+public sealed class AccountController : Controller
+{
+    private readonly AuthOptions _authOptions;
+    private readonly HtmlEncoder _htmlEncoder;
+
+    public AccountController(IOptions<AuthOptions> authOptions, HtmlEncoder htmlEncoder)
+    {
+        _authOptions = authOptions.Value;
+        _htmlEncoder = htmlEncoder;
+    }
+
+    [HttpGet("login")]
+    public IActionResult Login([FromQuery] string? returnUrl = null)
+    {
+        return Content(RenderLoginPage(returnUrl, null), "text/html; charset=utf-8");
+    }
+
+    [HttpPost("login")]
+    [Consumes("application/x-www-form-urlencoded")]
+    public async Task<IActionResult> LoginPost(
+        [FromForm] string username,
+        [FromForm] string password,
+        [FromForm] string? returnUrl = null)
+    {
+        var user = _authOptions.Users.FirstOrDefault(user =>
+            user.Username == username && user.Password == password);
+
+        if (user is null)
+        {
+            // 中文注释: 登录页认证失败时只重新显示表单，不把密码写入 URL 或日志。
+            return Content(RenderLoginPage(returnUrl, "The username or password is invalid."), "text/html; charset=utf-8");
+        }
+
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, user.Username),
+            new(ClaimTypes.Name, user.Username),
+            new(ClaimTypes.Role, user.Role)
+        };
+
+        foreach (var scope in user.Scopes)
+        {
+            claims.Add(new Claim("scope", scope));
+        }
+
+        var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+        await HttpContext.SignInAsync(
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            new ClaimsPrincipal(identity));
+
+        return LocalRedirect(SanitizeReturnUrl(returnUrl));
+    }
+
+    [HttpPost("logout")]
+    public async Task<IActionResult> Logout()
+    {
+        await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        return Redirect("/account/login");
+    }
+
+    private string RenderLoginPage(string? returnUrl, string? error)
+    {
+        var encodedReturnUrl = _htmlEncoder.Encode(SanitizeReturnUrl(returnUrl));
+        var encodedError = error is null ? string.Empty : _htmlEncoder.Encode(error);
+        var errorMarkup = error is null ? string.Empty : $"<div class=\"alert\">{encodedError}</div>";
+
+        return $$"""
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AuthFlowLab Login</title>
+  <style>
+    :root {
+      color: #212529;
+      background: #f8f9fa;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+    body { display: grid; min-height: 100vh; place-items: center; margin: 0; padding: 1rem; }
+    main { width: min(100%, 380px); border: 1px solid #dee2e6; border-radius: .5rem; background: #fff; padding: 1.25rem; box-shadow: 0 .125rem .25rem rgba(0,0,0,.075); }
+    h1 { margin: 0 0 1rem; font-size: 1.5rem; }
+    label { display: grid; gap: .375rem; margin-bottom: .875rem; color: #343a40; font-size: .875rem; font-weight: 600; }
+    input { width: 100%; border: 1px solid #ced4da; border-radius: .375rem; padding: .5rem .75rem; font: inherit; }
+    input:focus { border-color: #86b7fe; outline: 0; box-shadow: 0 0 0 .25rem rgba(13,110,253,.25); }
+    button { width: 100%; border: 1px solid #0d6efd; border-radius: .375rem; padding: .5rem .75rem; color: #fff; background: #0d6efd; font: inherit; font-weight: 600; cursor: pointer; }
+    button:hover { background: #0b5ed7; }
+    .eyebrow { margin: 0 0 .25rem; color: #6c757d; font-size: .75rem; font-weight: 700; text-transform: uppercase; }
+    .alert { margin-bottom: .875rem; border: 1px solid #f5c2c7; border-radius: .375rem; padding: .625rem .75rem; color: #842029; background: #f8d7da; font-size: .875rem; }
+  </style>
+</head>
+<body>
+  <main>
+    <p class="eyebrow">Auth Server</p>
+    <h1>Sign in</h1>
+    {{errorMarkup}}
+    <form method="post" action="/account/login">
+      <input type="hidden" name="returnUrl" value="{{encodedReturnUrl}}">
+      <label>
+        Username
+        <input name="username" autocomplete="username" required>
+      </label>
+      <label>
+        Password
+        <input name="password" type="password" autocomplete="current-password" required>
+      </label>
+      <button type="submit">Continue</button>
+    </form>
+  </main>
+</body>
+</html>
+""";
+    }
+
+    private string SanitizeReturnUrl(string? returnUrl)
+    {
+        return Url.IsLocalUrl(returnUrl) ? returnUrl! : "/";
+    }
+}

--- a/backend/AuthFlowLab.AuthServer/Controllers/ConnectController.cs
+++ b/backend/AuthFlowLab.AuthServer/Controllers/ConnectController.cs
@@ -50,9 +50,7 @@ public class ConnectController : ControllerBase
         [FromQuery(Name = "state")] string? state,
         [FromQuery] string? nonce,
         [FromQuery(Name = "code_challenge")] string? codeChallenge,
-        [FromQuery(Name = "code_challenge_method")] string? codeChallengeMethod,
-        [FromQuery] string? username,
-        [FromQuery] string? password)
+        [FromQuery(Name = "code_challenge_method")] string? codeChallengeMethod)
     {
         /*
          * Authorization Code + PKCE has two server-side steps.
@@ -60,8 +58,7 @@ public class ConnectController : ControllerBase
          * Step 1: /connect/authorize
          * - The browser/front-end sends client_id, redirect_uri, scope, state, nonce, and code_challenge.
          * - AuthServer validates the registered client and redirect_uri.
-         * - AuthServer authenticates the user. This lab temporarily uses username/password query
-         *   values to simulate a login page; a real app should show a login form instead.
+         * - AuthServer authenticates the user with its own login page and cookie.
          * - AuthServer creates a short-lived one-time code and stores the PKCE code_challenge
          *   together with that code.
          * - AuthServer redirects back to redirect_uri with code and state.
@@ -90,12 +87,19 @@ public class ConnectController : ControllerBase
             return BadRequest(new AuthErrorResponse("invalid_request", "PKCE S256 code_challenge is required."));
         }
 
-        var user = _authOptions.Users.FirstOrDefault(user =>
-            user.Username == username && user.Password == password);
+        if (User.Identity?.IsAuthenticated != true)
+        {
+            // 中文注释: 未登录时跳转到 Auth Server 登录页，保留原始 authorize URL 作为登录后的 returnUrl。
+            var returnUrl = Request.PathBase + Request.Path + Request.QueryString;
+            var loginUrl = QueryHelpers.AddQueryString("/account/login", "returnUrl", returnUrl);
+            return Redirect(loginUrl);
+        }
 
+        var username = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? User.FindFirstValue(ClaimTypes.Name);
+        var user = _authOptions.Users.FirstOrDefault(user => user.Username == username);
         if (user is null)
         {
-            return Unauthorized(new AuthErrorResponse("invalid_grant", "The username or password is invalid."));
+            return Unauthorized(new AuthErrorResponse("invalid_grant", "The signed-in user is no longer valid."));
         }
 
         var requestedScopes = ResolveRequestedScopes(scope, user.Scopes);

--- a/backend/AuthFlowLab.AuthServer/Program.cs
+++ b/backend/AuthFlowLab.AuthServer/Program.cs
@@ -1,5 +1,6 @@
 using AuthFlowLab.AuthServer.Options;
 using AuthFlowLab.AuthServer.Services;
+using Microsoft.AspNetCore.Authentication.Cookies;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -23,6 +24,18 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services
+    .AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie(options =>
+    {
+        options.LoginPath = "/account/login";
+        options.Cookie.Name = "AuthFlowLab.Auth";
+        options.Cookie.HttpOnly = true;
+        options.Cookie.SameSite = SameSiteMode.Lax;
+        options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+    });
+
+builder.Services.AddAuthorization();
 builder.Services.Configure<AuthOptions>(builder.Configuration.GetSection("Auth"));
 builder.Services.AddSingleton<RsaKeyService>();
 builder.Services.AddSingleton<JwtService>();
@@ -35,6 +48,8 @@ app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
 app.UseCors(FrontendCorsPolicy);
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapControllers();
 

--- a/backend/AuthFlowLab.http
+++ b/backend/AuthFlowLab.http
@@ -65,9 +65,10 @@ Accept: application/json
 grant_type=client_credentials&client_id=worker-service&client_secret=worker-secret&scope=content.read%20content.write
 
 ### Start authorization_code + PKCE
-# Browser receives 302. Copy code from the Location callback URL.
+# Browser receives 302 to /account/login unless it already has the Auth Server login cookie.
+# After login, copy code from the Location callback URL.
 # code_verifier = demo-code-verifier-1234567890
-GET {{AuthServer}}/connect/authorize?response_type=code&client_id=demo-spa&redirect_uri=http%3A%2F%2F127.0.0.1%3A5173%2Fcallback&scope=openid%20profile%20content.read&state=demo-state&nonce=demo-nonce&code_challenge=mvtzfCbIJ5YDPp1UVYfCnz2ZSvRrCEUgWtyrhVS6xo8&code_challenge_method=S256&username=user&password=user123
+GET {{AuthServer}}/connect/authorize?response_type=code&client_id=demo-spa&redirect_uri=http%3A%2F%2F127.0.0.1%3A5173%2Fcallback&scope=openid%20profile%20content.read&state=demo-state&nonce=demo-nonce&code_challenge=mvtzfCbIJ5YDPp1UVYfCnz2ZSvRrCEUgWtyrhVS6xo8&code_challenge_method=S256
 Accept: application/json
 
 ### Exchange authorization code for user token

--- a/frontend/AuthFlowLab.Web/src/App.tsx
+++ b/frontend/AuthFlowLab.Web/src/App.tsx
@@ -8,8 +8,6 @@ import { TokenPanel } from './components/TokenPanel';
 import type { CallResult, TokenResponse } from './types';
 
 export function App() {
-  const [username, setUsername] = useState('user');
-  const [password, setPassword] = useState('user123');
   const [tokens, setTokens] = useState<TokenResponse | null>(() => readTokens());
   const [message, setMessage] = useState('');
   const [result, setResult] = useState<CallResult | null>(null);
@@ -35,7 +33,7 @@ export function App() {
   async function handleLogin() {
     setMessage('');
     setResult(null);
-    await startLogin(username, password);
+    await startLogin();
   }
 
   async function callApi(path: string, label: string) {
@@ -64,12 +62,8 @@ export function App() {
     <main className="app-shell">
       <LoginPanel
         message={message}
-        password={password}
-        username={username}
         onClear={logout}
         onLogin={() => void handleLogin()}
-        onPasswordChange={setPassword}
-        onUsernameChange={setUsername}
       />
 
       <SessionPanel

--- a/frontend/AuthFlowLab.Web/src/auth.ts
+++ b/frontend/AuthFlowLab.Web/src/auth.ts
@@ -1,7 +1,7 @@
 import { authServer, clientId, redirectUri, scope, storageKeys } from './config';
 import type { TokenResponse } from './types';
 
-export async function startLogin(username: string, password: string) {
+export async function startLogin() {
   const verifier = base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)));
   const challenge = await createCodeChallenge(verifier);
   const state = base64UrlEncode(crypto.getRandomValues(new Uint8Array(16)));
@@ -20,8 +20,6 @@ export async function startLogin(username: string, password: string) {
   authorizeUrl.searchParams.set('nonce', nonce);
   authorizeUrl.searchParams.set('code_challenge', challenge);
   authorizeUrl.searchParams.set('code_challenge_method', 'S256');
-  authorizeUrl.searchParams.set('username', username);
-  authorizeUrl.searchParams.set('password', password);
 
   window.location.assign(authorizeUrl.toString());
 }

--- a/frontend/AuthFlowLab.Web/src/components/LoginPanel.tsx
+++ b/frontend/AuthFlowLab.Web/src/components/LoginPanel.tsx
@@ -1,19 +1,11 @@
 type LoginPanelProps = {
-  username: string;
-  password: string;
   message: string;
-  onUsernameChange: (value: string) => void;
-  onPasswordChange: (value: string) => void;
   onLogin: () => void;
   onClear: () => void;
 };
 
 export function LoginPanel({
-  username,
-  password,
   message,
-  onUsernameChange,
-  onPasswordChange,
   onLogin,
   onClear
 }: LoginPanelProps) {
@@ -24,15 +16,9 @@ export function LoginPanel({
         <h1>AuthFlowLab</h1>
       </div>
 
-      <label className="form-field">
-        Username
-        <input value={username} onChange={(event) => onUsernameChange(event.target.value)} />
-      </label>
-
-      <label className="form-field">
-        Password
-        <input value={password} onChange={(event) => onPasswordChange(event.target.value)} type="password" />
-      </label>
+      <p className="muted">
+        Sign in on the Auth Server. The SPA only starts the PKCE authorization request.
+      </p>
 
       <div className="button-row">
         <button type="button" className="btn btn-primary" onClick={onLogin}>

--- a/frontend/AuthFlowLab.Web/src/styles.css
+++ b/frontend/AuthFlowLab.Web/src/styles.css
@@ -148,6 +148,13 @@ input:focus {
   font-size: 0.875rem;
 }
 
+.muted {
+  margin-bottom: 0;
+  color: #6c757d;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
 .card-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Add Auth Server-hosted login page and HTTP-only cookie sign-in
- Redirect unauthenticated authorize requests to `/account/login` with the original authorize URL as `returnUrl`
- Remove username/password from the SPA authorize URL and login panel
- Update tests, README, and HTTP examples for the Auth Server login flow

## Tests
- `npm run build`
- `dotnet test backend\\AuthFlowLab.sln -c Release /p:UseAppHost=false`