### PR TITLE
Add Chinese comments to key auth flow code

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,31 @@ npm run build
 - `frontend/AuthFlowLab.Web/package-lock.json` is committed on purpose. This is an application, and the lock file keeps `npm ci` and Docker builds reproducible.
 - Build output such as `bin/`, `obj/`, `node_modules/`, `dist/`, and `*.tsbuildinfo` is ignored.
 
+## Key Code Map
+
+Auth Server:
+
+- `backend/AuthFlowLab.AuthServer/Program.cs` wires CORS, cookie authentication, authorization, Swagger, and controllers.
+- `backend/AuthFlowLab.AuthServer/Controllers/AccountController.cs` owns the IdP login page and HTTP-only login cookie.
+- `backend/AuthFlowLab.AuthServer/Controllers/ConnectController.cs` owns `/connect/authorize`, `/connect/token`, UserInfo, PKCE validation, scope checks, and code exchange.
+- `backend/AuthFlowLab.AuthServer/Controllers/DiscoveryController.cs` exposes OIDC discovery metadata and JWKS.
+- `backend/AuthFlowLab.AuthServer/Services/JwtService.cs` signs user access tokens, service access tokens, and OIDC ID tokens.
+- `backend/AuthFlowLab.AuthServer/Services/RsaKeyService.cs` loads or generates the RSA signing key and exports the public JWKS key.
+- `backend/AuthFlowLab.AuthServer/Services/AuthorizationCodeStore.cs` stores short-lived one-time authorization codes.
+
+API Server:
+
+- `backend/AuthFlowLab.ApiServer/Program.cs` configures JWT bearer validation, API-key authentication, and authorization policies.
+- `backend/AuthFlowLab.ApiServer/Controllers/ContentController.cs` demonstrates anonymous, authenticated, role, scope, service-only, and API-key endpoints.
+- `backend/AuthFlowLab.ApiServer/Authentication/ApiKeyAuthenticationHandler.cs` validates `X-Api-Key` locally and creates claims for the API-key policy.
+
+Frontend:
+
+- `frontend/AuthFlowLab.Web/src/auth.ts` generates PKCE values, starts `/connect/authorize`, exchanges callback `code` for tokens, validates `state`/`nonce`, and stores demo tokens.
+- `frontend/AuthFlowLab.Web/src/App.tsx` coordinates login callback handling, API calls, and local logout.
+- `frontend/AuthFlowLab.Web/src/components/*` contains the login, session, result, and token display panels.
+- `frontend/AuthFlowLab.Web/src/config.ts` centralizes demo URLs, client id, redirect URI, scope, and storage keys.
+
 ## Browser Flow
 
 1. Start Auth Server on `http://127.0.0.1:5001`.

--- a/backend/AuthFlowLab.ApiServer/Authentication/ApiKeyAuthenticationHandler.cs
+++ b/backend/AuthFlowLab.ApiServer/Authentication/ApiKeyAuthenticationHandler.cs
@@ -17,7 +17,7 @@ public sealed class ApiKeyAuthenticationHandler : AuthenticationHandler<ApiKeyAu
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        // API keys are validated locally by ApiServer. They do not call AuthServer or create JWTs.
+        // 中文注释: API key 由 ApiServer 本地校验，不调用 AuthServer，也不生成 JWT。
         if (!Request.Headers.TryGetValue(ApiKeyAuthenticationDefaults.HeaderName, out var headerValues))
         {
             return Task.FromResult(AuthenticateResult.NoResult());
@@ -35,7 +35,7 @@ public sealed class ApiKeyAuthenticationHandler : AuthenticationHandler<ApiKeyAu
             return Task.FromResult(AuthenticateResult.Fail("The API key is invalid."));
         }
 
-        // Once authenticated, expose claims so authorization policies can make finer decisions.
+        // 中文注释: 认证成功后把 API key 身份转成 ClaimsPrincipal，供授权策略继续判断。
         var claims = new[]
         {
             new Claim(ClaimTypes.NameIdentifier, credential.Name),

--- a/backend/AuthFlowLab.ApiServer/Program.cs
+++ b/backend/AuthFlowLab.ApiServer/Program.cs
@@ -72,6 +72,7 @@ builder.Services
     .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
+        // 中文注释: API Server 通过 Authority 读取 discovery/JWKS，并验证 Auth Server 签发的 JWT。
         options.Authority = builder.Configuration["Jwt:Authority"] ?? "http://127.0.0.1:5001";
         options.Audience = builder.Configuration["Jwt:Audience"] ?? "api-server";
         options.RequireHttpsMetadata = builder.Configuration.GetValue("Jwt:RequireHttpsMetadata", false);
@@ -96,6 +97,7 @@ builder.Services.AddAuthorization(options =>
 {
     options.AddPolicy("ContentRead", policy => policy.RequireAssertion(context =>
     {
+        // 中文注释: scope 在 JWT 里是空格分隔字符串，这里拆开后判断是否包含 content.read。
         return context.User.FindAll("scope")
             .SelectMany(claim => claim.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
             .Contains("content.read", StringComparer.Ordinal);
@@ -103,6 +105,7 @@ builder.Services.AddAuthorization(options =>
 
     options.AddPolicy("ContentWrite", policy => policy.RequireAssertion(context =>
     {
+        // 中文注释: 写接口要求 content.write，普通 user token 会因为 scope 不足得到 403。
         return context.User.FindAll("scope")
             .SelectMany(claim => claim.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
             .Contains("content.write", StringComparer.Ordinal);
@@ -110,11 +113,13 @@ builder.Services.AddAuthorization(options =>
 
     options.AddPolicy("ServiceOnly", policy => policy.RequireAssertion(context =>
     {
+        // 中文注释: 服务专用接口只接受 client_credentials 发出的 token_type=service。
         return context.User.HasClaim(c => c.Type == "token_type" && c.Value == "service");
     }));
 
     options.AddPolicy("ApiKeyOnly", policy =>
     {
+        // 中文注释: API Key 走独立 authentication scheme，不依赖 Bearer JWT。
         policy.AuthenticationSchemes.Add(ApiKeyAuthenticationDefaults.AuthenticationScheme);
         policy.RequireAuthenticatedUser();
         policy.RequireClaim("token_type", "api_key");

--- a/backend/AuthFlowLab.AuthServer/Controllers/AccountController.cs
+++ b/backend/AuthFlowLab.AuthServer/Controllers/AccountController.cs
@@ -24,6 +24,7 @@ public sealed class AccountController : Controller
     [HttpGet("login")]
     public IActionResult Login([FromQuery] string? returnUrl = null)
     {
+        // 中文注释: 登录页由 Auth Server 自己展示，SPA 不再收集或传递用户密码。
         return Content(RenderLoginPage(returnUrl, null), "text/html; charset=utf-8");
     }
 
@@ -55,6 +56,7 @@ public sealed class AccountController : Controller
             claims.Add(new Claim("scope", scope));
         }
 
+        // 中文注释: 登录成功只写入 HttpOnly cookie；真正给 SPA 的 token 仍然要走 /connect/token。
         var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
         await HttpContext.SignInAsync(
             CookieAuthenticationDefaults.AuthenticationScheme,
@@ -128,6 +130,7 @@ public sealed class AccountController : Controller
 
     private string SanitizeReturnUrl(string? returnUrl)
     {
+        // 中文注释: 只允许回跳到本站路径，避免登录后被恶意 returnUrl 带到外部网站。
         return Url.IsLocalUrl(returnUrl) ? returnUrl! : "/";
     }
 }

--- a/backend/AuthFlowLab.AuthServer/Controllers/ConnectController.cs
+++ b/backend/AuthFlowLab.AuthServer/Controllers/ConnectController.cs
@@ -102,6 +102,7 @@ public class ConnectController : ControllerBase
             return Unauthorized(new AuthErrorResponse("invalid_grant", "The signed-in user is no longer valid."));
         }
 
+        // 中文注释: scope 同时受用户权限和客户端注册权限约束，OIDC scope 不等同于 API 权限。
         var requestedScopes = ResolveRequestedScopes(scope, user.Scopes);
         if (requestedScopes.Contains("openid", StringComparer.Ordinal) && string.IsNullOrWhiteSpace(nonce))
         {
@@ -114,6 +115,7 @@ public class ConnectController : ControllerBase
             return BadRequest(new AuthErrorResponse("invalid_scope", "The requested scope is not allowed for this user or client."));
         }
 
+        // 中文注释: 授权码只保存服务端状态，浏览器地址栏只拿到一次性 code 和原始 state。
         var code = _authorizationCodeStore.Create(
             client.ClientId,
             redirectUri,
@@ -179,6 +181,7 @@ public class ConnectController : ControllerBase
                 "The grant_type form field is required."));
         }
 
+        // 中文注释: token endpoint 同时承载服务身份的 client_credentials 和用户登录后的 authorization_code。
         return grantType switch
         {
             ClientCredentialsGrantType => HandleClientCredentials(clientId, clientSecret, scope),
@@ -216,6 +219,7 @@ public class ConnectController : ControllerBase
                 "The requested scope is not allowed for this client."));
         }
 
+        // 中文注释: client_credentials 发的是服务 token，不代表任何用户。
         return Ok(_jwtService.GenerateServiceToken(client.ClientId, requestedScopes));
     }
 
@@ -259,6 +263,7 @@ public class ConnectController : ControllerBase
             return BadRequest(new AuthErrorResponse("invalid_grant", "The PKCE code_verifier is invalid."));
         }
 
+        // 中文注释: code、redirect_uri、client_id、PKCE 全部校验后，才签发用户 access_token/id_token。
         return Ok(_jwtService.GenerateUserToken(
             authorizationCode.Username,
             authorizationCode.Role,
@@ -322,6 +327,7 @@ public class ConnectController : ControllerBase
         var handler = new JwtSecurityTokenHandler();
         try
         {
+            // 中文注释: UserInfo 复用本 Auth Server 的签名公钥验证 access_token，避免信任未验证的 JWT 内容。
             return handler.ValidateToken(token, new TokenValidationParameters
             {
                 ValidateIssuer = true,

--- a/backend/AuthFlowLab.AuthServer/Controllers/DiscoveryController.cs
+++ b/backend/AuthFlowLab.AuthServer/Controllers/DiscoveryController.cs
@@ -21,6 +21,7 @@ public sealed class DiscoveryController : ControllerBase
     {
         var issuer = GetIssuer();
 
+        // 中文注释: discovery 文档告诉客户端和 API：authorize/token/userinfo/JWKS 端点在哪里、支持哪些能力。
         return Ok(new
         {
             issuer,
@@ -41,6 +42,7 @@ public sealed class DiscoveryController : ControllerBase
     [HttpGet("jwks.json")]
     public IActionResult Jwks()
     {
+        // 中文注释: JWKS 只暴露公钥参数，API Server 用它验证 JWT 签名，不需要 public.key 文件。
         return Ok(new
         {
             keys = new[] { _rsaKeyService.CreateJsonWebKey() }

--- a/backend/AuthFlowLab.AuthServer/Program.cs
+++ b/backend/AuthFlowLab.AuthServer/Program.cs
@@ -28,6 +28,7 @@ builder.Services
     .AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
     .AddCookie(options =>
     {
+        // 中文注释: Auth Server 用自己的登录 cookie 记录用户是否已经在 IdP 登录。
         options.LoginPath = "/account/login";
         options.Cookie.Name = "AuthFlowLab.Auth";
         options.Cookie.HttpOnly = true;
@@ -48,6 +49,8 @@ app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
 app.UseCors(FrontendCorsPolicy);
+
+// 中文注释: authorize 端点依赖 cookie 认证先还原 User，再决定是否跳登录页或发授权码。
 app.UseAuthentication();
 app.UseAuthorization();
 

--- a/backend/AuthFlowLab.AuthServer/Services/JwtService.cs
+++ b/backend/AuthFlowLab.AuthServer/Services/JwtService.cs
@@ -32,6 +32,8 @@ public class JwtService
     {
         var scopeList = scopes.ToList();
         var scope = string.Join(' ', scopeList);
+
+        // 中文注释: access_token 面向 API Server，包含用户、角色、scope 和 token_type=user。
         var claims = new List<Claim>
         {
             new(JwtRegisteredClaimNames.Sub, username),
@@ -44,6 +46,8 @@ public class JwtService
         };
 
         var accessToken = GenerateJwt(claims, GetApiAudience());
+
+        // 中文注释: 只有请求 openid scope 时才额外签发 id_token，供 SPA 识别登录用户。
         var idToken = scopeList.Contains("openid", StringComparer.Ordinal)
             ? GenerateIdToken(username, role, clientId, nonce)
             : null;
@@ -54,6 +58,8 @@ public class JwtService
     public TokenResponse GenerateServiceToken(string clientId, IEnumerable<string> scopes)
     {
         var scope = string.Join(' ', scopes);
+
+        // 中文注释: service token 代表客户端应用自身，适合后台任务或服务间调用。
         var claims = new List<Claim>
         {
             new(JwtRegisteredClaimNames.Sub, clientId),
@@ -97,6 +103,7 @@ public class JwtService
 
     private string GenerateJwt(List<Claim> claims, string audience)
     {
+        // 中文注释: 所有 JWT 都用 Auth Server 的 RSA 私钥签名；audience 决定 token 给谁使用。
         var token = new JwtSecurityToken(
             issuer: GetIssuer(),
             audience: audience,

--- a/backend/AuthFlowLab.AuthServer/Services/RsaKeyService.cs
+++ b/backend/AuthFlowLab.AuthServer/Services/RsaKeyService.cs
@@ -27,6 +27,7 @@ public sealed class RsaKeyService
 
     public SigningCredentials CreateSigningCredentials()
     {
+        // 中文注释: 私钥只留在 Auth Server 内部，用来签名 access_token 和 id_token。
         var signingKey = new RsaSecurityKey(_rsa.Value)
         {
             KeyId = KeyId
@@ -37,6 +38,7 @@ public sealed class RsaKeyService
 
     public JsonWebKey CreateJsonWebKey()
     {
+        // 中文注释: 从同一把 RSA key 导出公钥参数，供 JWKS endpoint 返回给 API Server。
         var parameters = _rsa.Value.ExportParameters(includePrivateParameters: false);
 
         return new JsonWebKey

--- a/frontend/AuthFlowLab.Web/src/App.tsx
+++ b/frontend/AuthFlowLab.Web/src/App.tsx
@@ -13,6 +13,7 @@ export function App() {
   const [result, setResult] = useState<CallResult | null>(null);
 
   const idTokenPayload = useMemo(() => {
+    // 中文注释: id_token 只用于前端展示登录用户信息，API 调用使用 access_token。
     return tokens?.id_token ? decodeJwtPayload(tokens.id_token) : null;
   }, [tokens]);
 
@@ -47,11 +48,14 @@ export function App() {
         Authorization: `Bearer ${tokens.access_token}`
       }
     });
+
+    // 中文注释: 这里展示 API 返回结果，方便观察 200/401/403 等授权效果。
     const body = await response.text();
     setResult({ label, status: response.status, body });
   }
 
   function logout() {
+    // 中文注释: 这里只清理 SPA 本地 token；Auth Server 的登录 cookie 可通过 /account/logout 扩展处理。
     clearSession();
     setTokens(null);
     setResult(null);

--- a/frontend/AuthFlowLab.Web/src/auth.ts
+++ b/frontend/AuthFlowLab.Web/src/auth.ts
@@ -2,6 +2,7 @@ import { authServer, clientId, redirectUri, scope, storageKeys } from './config'
 import type { TokenResponse } from './types';
 
 export async function startLogin() {
+  // 中文注释: SPA 只生成 PKCE 参数并跳转 authorize，不收集也不传递用户密码。
   const verifier = base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)));
   const challenge = await createCodeChallenge(verifier);
   const state = base64UrlEncode(crypto.getRandomValues(new Uint8Array(16)));
@@ -11,6 +12,7 @@ export async function startLogin() {
   sessionStorage.setItem(storageKeys.state, state);
   sessionStorage.setItem(storageKeys.nonce, nonce);
 
+  // 中文注释: state/nonce/verifier 留在浏览器本地，回调时用于防重放和校验 id_token。
   const authorizeUrl = new URL(`${authServer}/connect/authorize`);
   authorizeUrl.searchParams.set('response_type', 'code');
   authorizeUrl.searchParams.set('client_id', clientId);
@@ -35,6 +37,7 @@ export async function completeLoginCallback() {
   // 中文注释: 先移除 URL 中的一次性 code，避免 React 开发模式重复执行 effect 时再次换 token。
   window.history.replaceState({}, document.title, '/');
 
+  // 中文注释: state 必须和登录前保存的一致，否则拒绝继续换 token。
   if (!code || !verifier || !expectedState || returnedState !== expectedState) {
     throw new Error('Callback validation failed.');
   }
@@ -47,6 +50,7 @@ export async function completeLoginCallback() {
     code_verifier: verifier
   });
 
+  // 中文注释: authorization code 不能直接当 token 用，必须和 code_verifier 一起提交给 token endpoint。
   const response = await fetch(`${authServer}/connect/token`, {
     method: 'POST',
     headers: {
@@ -61,10 +65,13 @@ export async function completeLoginCallback() {
 
   const tokenResponse = (await response.json()) as TokenResponse;
   const idTokenPayload = tokenResponse.id_token ? decodeJwtPayload(tokenResponse.id_token) : null;
+
+  // 中文注释: nonce 用来确认 id_token 属于这次登录请求，不是旧登录响应被重放。
   if (idTokenPayload?.nonce !== expectedNonce) {
     throw new Error('Nonce validation failed.');
   }
 
+  // 中文注释: demo 为了便于观察把 token 存 localStorage；生产 SPA 需要额外评估 XSS 风险。
   localStorage.setItem(storageKeys.tokens, JSON.stringify(tokenResponse));
   return tokenResponse;
 }
@@ -91,6 +98,7 @@ export function decodeJwtPayload(token: string): Record<string, unknown> | null 
 }
 
 async function createCodeChallenge(verifier: string) {
+  // 中文注释: PKCE S256 = BASE64URL(SHA256(code_verifier))。
   const data = new TextEncoder().encode(verifier);
   const digest = await crypto.subtle.digest('SHA-256', data);
   return base64UrlEncode(new Uint8Array(digest));

--- a/frontend/AuthFlowLab.Web/src/components/LoginPanel.tsx
+++ b/frontend/AuthFlowLab.Web/src/components/LoginPanel.tsx
@@ -17,6 +17,7 @@ export function LoginPanel({
       </div>
 
       <p className="muted">
+        {/* 中文注释: 前端只启动 OAuth/OIDC 登录，用户名密码在 Auth Server 登录页输入。 */}
         Sign in on the Auth Server. The SPA only starts the PKCE authorization request.
       </p>
 

--- a/frontend/AuthFlowLab.Web/src/components/SessionPanel.tsx
+++ b/frontend/AuthFlowLab.Web/src/components/SessionPanel.tsx
@@ -23,6 +23,7 @@ export function SessionPanel({
       </div>
 
       <dl className="claim-list">
+        {/* 中文注释: 这些字段来自 id_token，表示“谁登录了”，不是 API 授权结果。 */}
         <ClaimItem label="Subject" value={stringClaim(idTokenPayload?.sub)} />
         <ClaimItem label="Name" value={stringClaim(idTokenPayload?.name)} />
         <ClaimItem label="Audience" value={stringClaim(idTokenPayload?.aud)} />
@@ -30,6 +31,7 @@ export function SessionPanel({
       </dl>
 
       <div className="button-row">
+        {/* 中文注释: 下面两个请求都会携带 access_token，浏览器会因为 Authorization header 先发 CORS preflight。 */}
         <button type="button" className="btn btn-primary" onClick={onCallApi}>
           Call API
         </button>

--- a/frontend/AuthFlowLab.Web/src/components/TokenPanel.tsx
+++ b/frontend/AuthFlowLab.Web/src/components/TokenPanel.tsx
@@ -7,6 +7,7 @@ export function TokenPanel({ accessToken, idToken }: TokenPanelProps) {
   return (
     <section className="card content-card">
       <h2>Tokens</h2>
+      {/* 中文注释: access_token 给 API 用；id_token 给 SPA 识别用户用。 */}
       <TokenBlock label="access_token" value={accessToken} />
       <TokenBlock label="id_token" value={idToken} />
     </section>

--- a/frontend/AuthFlowLab.Web/src/config.ts
+++ b/frontend/AuthFlowLab.Web/src/config.ts
@@ -1,5 +1,7 @@
 export const authServer = 'http://127.0.0.1:5001';
 export const apiServer = 'http://127.0.0.1:5002';
+
+// 中文注释: demo-spa 是公开客户端，不能保存 client_secret，所以使用 Authorization Code + PKCE。
 export const clientId = 'demo-spa';
 export const redirectUri = 'http://127.0.0.1:5173/callback';
 export const scope = 'openid profile content.read';


### PR DESCRIPTION
## Summary
- Add Chinese comments to important Auth Server, API Server, and frontend auth-flow code blocks
- Document PKCE, callback token exchange, JWT/JWKS, API policies, API key auth, and cookie login boundaries
- Add README key code map for backend and frontend files
- Confirm Docker compose configuration does not need changes

## Tests
- `npm run build`
- `dotnet test backend\\AuthFlowLab.sln -c Release /p:UseAppHost=false`
- `docker compose config`