### PR TITLE
Add token inspector and claims endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ These are development credentials for the local environment. Do not use committe
 | --- | --- |
 | `GET /content/public` | Anonymous |
 | `GET /content/user` | Any valid bearer token |
+| `GET /content/me` | Current authentication state and claims |
 | `GET /content/admin` | `Admin` role |
 | `GET /content/read` | Local `content.read` or Entra `access_as_user` |
 | `POST /content/write` | Local `content.write` or Entra `write_as_user` |

--- a/backend/AuthFlowLab.ApiServer.Tests/ContentEndpointTests.cs
+++ b/backend/AuthFlowLab.ApiServer.Tests/ContentEndpointTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using System.Security.Cryptography;
+using System.Text.Json;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -40,6 +41,25 @@ public sealed class ContentEndpointTests : IClassFixture<ApiServerFactory>
         var response = await _client.GetAsync("/content/user");
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MeContent_ReturnsCurrentPrincipalClaims()
+    {
+        UseBearerToken(_factory.CreateToken("user", tokenType: "user", role: "User", scope: "content.read"));
+
+        var response = await _client.GetAsync("/content/me");
+        var content = await response.Content.ReadAsStringAsync();
+
+        Assert.True(response.IsSuccessStatusCode, content);
+
+        using var document = JsonDocument.Parse(content);
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("authentication").GetProperty("isAuthenticated").GetBoolean());
+
+        var claims = root.GetProperty("claims");
+        Assert.Equal("user", claims.GetProperty(JwtRegisteredClaimNames.Sub).GetString());
+        Assert.Equal("content.read", claims.GetProperty("scope").GetString());
     }
 
     [Fact]

--- a/backend/AuthFlowLab.ApiServer/Controllers/ContentController.cs
+++ b/backend/AuthFlowLab.ApiServer/Controllers/ContentController.cs
@@ -7,7 +7,7 @@ namespace AuthFlowLab.ApiServer.Controllers;
 [Route("content")]
 public class ContentController : ControllerBase
 {
-    // 匿名接口：不需要 token，适合验证 API 是否活着。
+    // 匿名接口：不需要 token，适合验证 API 是否存活。
     [HttpGet("public")]
     [AllowAnonymous]
     public IActionResult Public()
@@ -19,25 +19,55 @@ public class ContentController : ControllerBase
     public IActionResult UserContent()
         => Ok("User or authenticated service content");
 
-    // 角色授权：要求 token 里有 role=Admin。
+    // 当前身份调试接口：返回 ASP.NET Core 认证后的 Identity 和 Claims，方便对比本地 JWT、Entra JWT、API Key 的差异。
+    [HttpGet("me")]
+    [Authorize]
+    public IActionResult Me()
+        => Ok(new
+        {
+            authentication = new
+            {
+                isAuthenticated = User.Identity?.IsAuthenticated ?? false,
+                name = User.Identity?.Name,
+                authenticationType = User.Identity?.AuthenticationType,
+                identities = User.Identities.Select(identity => new
+                {
+                    identity.AuthenticationType,
+                    identity.Name,
+                    identity.IsAuthenticated
+                })
+            },
+            claims = User.Claims
+                .GroupBy(claim => claim.Type)
+                .OrderBy(group => group.Key, StringComparer.Ordinal)
+                .ToDictionary(
+                    group => group.Key,
+                    group => ToClaimValue(group
+                        .Select(claim => claim.Value)
+                        .Distinct(StringComparer.Ordinal)
+                        .OrderBy(value => value, StringComparer.Ordinal)
+                        .ToArray()))
+        });
+
+    // 角色授权：要求 token 里有 Admin role。
     [HttpGet("admin")]
     [Authorize(Roles = "Admin")]
     public IActionResult AdminContent()
         => Ok("Admin content");
 
-    // scope 授权：要求 token 里包含 content.read。
+    // scope 授权：本地 token 使用 scope，Entra token 使用 scp。
     [HttpGet("read")]
     [Authorize(Policy = "ContentRead")]
     public IActionResult ReadContent()
         => Ok("Content read allowed");
 
-    // 更细粒度的写权限：普通 user 没有 content.write，会得到 403。
+    // 更细粒度的写权限：普通 user 没有 write scope 时会得到 403。
     [HttpPost("write")]
     [Authorize(Policy = "ContentWrite")]
     public IActionResult WriteContent()
         => Ok("Content write allowed");
 
-    // 服务调用授权：要求 token_type=service，用户 token 不能访问。
+    // 服务调用授权：要求 token_type=service，普通用户 token 不能访问。
     [HttpGet("service")]
     [Authorize(Policy = "ServiceOnly")]
     public IActionResult ServiceContent()
@@ -48,4 +78,7 @@ public class ContentController : ControllerBase
     [Authorize(Policy = "ApiKeyOnly")]
     public IActionResult ApiKeyContent()
         => Ok("API key content");
+
+    private static object ToClaimValue(string[] values)
+        => values.Length == 1 ? values[0] : values;
 }

--- a/frontend/AuthFlowLab.Web/src/App.tsx
+++ b/frontend/AuthFlowLab.Web/src/App.tsx
@@ -141,18 +141,26 @@ export function App() {
         onLogin={() => void handleLogin()}
       />
 
+      {/* 中文注释：Claims 按钮会调用 /content/me，查看 token 在 API 中被解析成哪些 Identity 和 Claims。 */}
       <SessionPanel
         accessTokenPayload={accessTokenPayload}
         idTokenPayload={idTokenPayload}
         provider={tokens?.provider}
         isAuthenticated={Boolean(tokens)}
         onCallApi={() => void callApi(`${apiServer}/content/read`, 'ApiServer /content/read')}
+        onCallClaims={() => void callApi(`${apiServer}/content/me`, 'ApiServer /content/me')}
         onCallWriteApi={() => void callApi(`${apiServer}/content/write`, 'ApiServer /content/write', 'POST')}
         onUserInfo={() => void callUserInfo()}
       />
 
       <ResultPanel result={result} />
-      <TokenPanel accessToken={tokens?.access_token} idToken={tokens?.id_token} />
+      <TokenPanel
+        accessToken={tokens?.access_token}
+        accessTokenPayload={accessTokenPayload}
+        idToken={tokens?.id_token}
+        idTokenPayload={idTokenPayload}
+        provider={tokens?.provider}
+      />
     </main>
   );
 }

--- a/frontend/AuthFlowLab.Web/src/components/SessionPanel.tsx
+++ b/frontend/AuthFlowLab.Web/src/components/SessionPanel.tsx
@@ -6,6 +6,7 @@ type SessionPanelProps = {
   provider?: 'local' | 'entra';
   isAuthenticated: boolean;
   onCallApi: () => void;
+  onCallClaims: () => void;
   onCallWriteApi: () => void;
   onUserInfo: () => void;
 };
@@ -16,6 +17,7 @@ export function SessionPanel({
   provider,
   isAuthenticated,
   onCallApi,
+  onCallClaims,
   onCallWriteApi,
   onUserInfo
 }: SessionPanelProps) {
@@ -39,6 +41,10 @@ export function SessionPanel({
       <div className="button-row">
         <button type="button" className="btn btn-primary" onClick={onCallApi}>
           Call Read API
+        </button>
+        {/* 中文注释：Claims 按钮用于查看 API Server 认证后的服务端 claims，而不是只看浏览器里解码的 JWT。 */}
+        <button type="button" className="btn btn-primary" onClick={onCallClaims}>
+          Claims
         </button>
         <button type="button" className="btn btn-primary" onClick={onCallWriteApi}>
           Call Write API

--- a/frontend/AuthFlowLab.Web/src/components/TokenPanel.tsx
+++ b/frontend/AuthFlowLab.Web/src/components/TokenPanel.tsx
@@ -1,16 +1,48 @@
+import { stringClaim } from '../format';
+
 type TokenPanelProps = {
   accessToken?: string;
+  accessTokenPayload: Record<string, unknown> | null;
   idToken?: string;
+  idTokenPayload: Record<string, unknown> | null;
+  provider?: 'local' | 'entra';
 };
 
-export function TokenPanel({ accessToken, idToken }: TokenPanelProps) {
+export function TokenPanel({
+  accessToken,
+  accessTokenPayload,
+  idToken,
+  idTokenPayload,
+  provider
+}: TokenPanelProps) {
   return (
     <section className="card content-card">
-      <h2>Tokens</h2>
-      {/* 中文注释: access_token 给 API 用；id_token 给 SPA 识别用户用。 */}
+      <h2>Token Inspector</h2>
+
+      {/* 中文注释：这里解码浏览器当前持有的 JWT，帮助对比本地 IdP token 和 Entra ID token 的 issuer、audience、scope。 */}
+      <dl className="claim-list">
+        <ClaimItem label="Provider" value={provider ?? inferProvider(accessTokenPayload)} />
+        <ClaimItem label="Issuer" value={stringClaim(accessTokenPayload?.iss)} />
+        <ClaimItem label="Audience" value={stringClaim(accessTokenPayload?.aud)} />
+        <ClaimItem label="Subject" value={stringClaim(accessTokenPayload?.sub ?? idTokenPayload?.sub)} />
+        <ClaimItem label="Scopes" value={stringClaim(accessTokenPayload?.scp ?? accessTokenPayload?.scope)} />
+        <ClaimItem label="Roles" value={stringClaim(accessTokenPayload?.roles ?? accessTokenPayload?.role)} />
+        <ClaimItem label="Expires" value={formatUnixTime(accessTokenPayload?.exp)} />
+        <ClaimItem label="Token Use" value={idToken ? 'access_token + id_token' : accessToken ? 'access_token' : '-'} />
+      </dl>
+
       <TokenBlock label="access_token" value={accessToken} />
       <TokenBlock label="id_token" value={idToken} />
     </section>
+  );
+}
+
+function ClaimItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="claim-item">
+      <dt>{label}</dt>
+      <dd>{value}</dd>
+    </div>
   );
 }
 
@@ -21,4 +53,22 @@ function TokenBlock({ label, value }: { label: string; value?: string }) {
       <pre>{value ?? '-'}</pre>
     </div>
   );
+}
+
+function inferProvider(payload: Record<string, unknown> | null) {
+  // 中文注释：根据 issuer 粗略推断 token 来自 Entra ID 还是本地 AuthServer；最终安全判断仍由 API Server 的 JWT 验证完成。
+  const issuer = stringClaim(payload?.iss);
+  if (issuer.startsWith('https://login.microsoftonline.com/') || issuer.startsWith('https://sts.windows.net/')) {
+    return 'entra';
+  }
+
+  return issuer === '-' ? '-' : 'local';
+}
+
+function formatUnixTime(value: unknown) {
+  if (typeof value !== 'number') {
+    return '-';
+  }
+
+  return `${new Date(value * 1000).toLocaleString()} (${value})`;
 }


### PR DESCRIPTION
## Summary
- Add /content/me to return the current authentication state and grouped claims
- Add a Token Inspector panel for key JWT fields
- Add a Claims action in the SPA to compare client-side JWT decoding with server-side claims

## Testing
- dotnet test backend/AuthFlowLab.sln
- npm run build