### PR TITLE
Document auth flows and test Entra JWT validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,55 @@ flowchart LR
 
 The Auth Server signs local JWTs and publishes its public key through JWKS. The API Server loads signing keys from `Jwt:Authority` for local tokens and validates Entra ID tokens through `Jwt:Entra:Authority` and `Jwt:Entra:Audience`.
 
+## Local vs Entra
+
+| Concept | Local Auth Server | Microsoft Entra ID |
+| --- | --- | --- |
+| Identity provider | `AuthFlowLab.AuthServer` | Microsoft Entra ID tenant |
+| Browser client | `demo-spa` in appsettings | SPA app registration |
+| Protected API | `aud=api-server` configuration | API app registration |
+| Token issuer | Local Auth Server URL | `login.microsoftonline.com` |
+| Signing keys | Local JWKS | Microsoft JWKS |
+| Scope claim | `scope` | `scp` |
+| API validation scheme | `LocalJwt` | `EntraJwt` |
+
+## Flows
+
+Local authorization code + PKCE:
+
+```mermaid
+sequenceDiagram
+    participant Browser as React SPA
+    participant Auth as AuthFlowLab Auth Server
+    participant Api as AuthFlowLab API Server
+
+    Browser->>Auth: /connect/authorize with code_challenge
+    Auth-->>Browser: Redirect to /callback with code
+    Browser->>Auth: /connect/token with code_verifier
+    Auth-->>Browser: access_token and id_token
+    Browser->>Api: API request with local bearer token
+    Api->>Auth: Load discovery metadata and JWKS
+    Api-->>Browser: Authorized response
+```
+
+Entra authorization code + PKCE:
+
+```mermaid
+sequenceDiagram
+    participant Browser as React SPA
+    participant Entra as Microsoft Entra ID
+    participant Api as AuthFlowLab API Server
+    participant Graph as Microsoft Graph
+
+    Browser->>Entra: MSAL loginRedirect with API scopes
+    Entra-->>Browser: Redirect to /callback with auth result
+    Browser->>Entra: MSAL acquires API access token
+    Browser->>Api: API request with Entra bearer token
+    Api->>Entra: Load discovery metadata and JWKS
+    Api-->>Browser: Authorized response
+    Browser->>Graph: /me with Graph access token
+```
+
 ## Entra ID
 
 The repository is configured for a protected API registration and a browser SPA registration:

--- a/backend/AuthFlowLab.ApiServer.Tests/ContentEndpointTests.cs
+++ b/backend/AuthFlowLab.ApiServer.Tests/ContentEndpointTests.cs
@@ -88,6 +88,20 @@ public sealed class ContentEndpointTests : IClassFixture<ApiServerFactory>
     }
 
     [Fact]
+    public async Task ReadContent_AllowsEntraJwtBearerToken()
+    {
+        // 中文注释：这个 token 使用 Entra issuer/audience 和独立签名 key，只配置给 EntraJwt scheme。
+        // 如果请求成功，说明 SmartBearer 正确分流到了 EntraJwt，而不是误走 LocalJwt。
+        UseBearerToken(_factory.CreateEntraToken("entra-user", scp: "access_as_user"));
+
+        var response = await _client.GetAsync("/content/read");
+        var content = await response.Content.ReadAsStringAsync();
+
+        Assert.True(response.IsSuccessStatusCode, content);
+        Assert.Equal("Content read allowed", content);
+    }
+
+    [Fact]
     public async Task WriteContent_RejectsUserWithoutContentWriteScope()
     {
         UseBearerToken(_factory.CreateToken("user", tokenType: "user", role: "User", scope: "content.read"));
@@ -178,6 +192,7 @@ public sealed class ContentEndpointTests : IClassFixture<ApiServerFactory>
 public sealed class ApiServerFactory : WebApplicationFactory<Program>
 {
     private readonly RSA _rsa = RSA.Create(2048);
+    private readonly RSA _entraRsa = RSA.Create(2048);
 
     public ApiServerFactory()
     {
@@ -219,6 +234,29 @@ public sealed class ApiServerFactory : WebApplicationFactory<Program>
         return new JwtSecurityTokenHandler().WriteToken(token);
     }
 
+    public string CreateEntraToken(string subject, string scp)
+    {
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, subject),
+            new("scp", scp),
+            new("name", "Entra Test User")
+        };
+
+        // 中文注释：这里模拟 Entra ID access token 的关键字段，重点覆盖 issuer、audience 和 scp。
+        var token = new JwtSecurityToken(
+            issuer: "https://login.microsoftonline.com/976c3c85-e425-4880-a658-3653df9cebf2/v2.0",
+            audience: "api://b5b7fdde-0835-4e46-863d-463b1432e9f7",
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(10),
+            signingCredentials: new SigningCredentials(new RsaSecurityKey(_entraRsa)
+            {
+                KeyId = "entra-test-key"
+            }, SecurityAlgorithms.RsaSha256));
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseContentRoot(FindProjectDirectory("AuthFlowLab.ApiServer"));
@@ -229,6 +267,8 @@ public sealed class ApiServerFactory : WebApplicationFactory<Program>
                 ["Jwt:Authority"] = "http://auth-flow-lab.test",
                 ["Jwt:Audience"] = "api-server",
                 ["Jwt:RequireHttpsMetadata"] = "false",
+                ["Jwt:Entra:Authority"] = "https://login.microsoftonline.com/976c3c85-e425-4880-a658-3653df9cebf2/v2.0",
+                ["Jwt:Entra:Audience"] = "api://b5b7fdde-0835-4e46-863d-463b1432e9f7",
                 ["ApiKeys:Keys:0:Name"] = "test-tool",
                 ["ApiKeys:Keys:0:Value"] = "test-api-key"
             });
@@ -246,6 +286,24 @@ public sealed class ApiServerFactory : WebApplicationFactory<Program>
                 options.Configuration = new OpenIdConnectConfiguration
                 {
                     Issuer = "http://auth-flow-lab.test"
+                };
+
+                options.Configuration.SigningKeys.Add(signingKey);
+                options.TokenValidationParameters.IssuerSigningKey = signingKey;
+                options.TokenValidationParameters.TryAllIssuerSigningKeys = true;
+            });
+
+            services.PostConfigure<JwtBearerOptions>("EntraJwt", options =>
+            {
+                var signingKey = new RsaSecurityKey(_entraRsa)
+                {
+                    KeyId = "entra-test-key"
+                };
+
+                // 中文注释：测试环境不访问 Microsoft discovery endpoint，直接注入模拟的 Entra JWKS 配置。
+                options.Configuration = new OpenIdConnectConfiguration
+                {
+                    Issuer = "https://login.microsoftonline.com/976c3c85-e425-4880-a658-3653df9cebf2/v2.0"
                 };
 
                 options.Configuration.SigningKeys.Add(signingKey);


### PR DESCRIPTION
## Summary
- Add Local vs Entra identity flow comparison to README
- Add Mermaid sequence diagrams for local PKCE and Entra PKCE flows
- Add an API Server test that validates an Entra-style JWT through the EntraJwt scheme

## Testing
- dotnet test backend/AuthFlowLab.sln
- npm run build