### PR TITLE
Add Entra federated SSO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ keys/*.key
 *.user
 *.suo
 *.local.http
+docker-compose.local.yml
 
 # Ignore build output
 bin/

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ The project focuses on the parts that matter in production systems: token issuan
 
 ## What It Covers
 
-- Custom Auth Server with OAuth2 authorization code + PKCE, client credentials, OIDC discovery, UserInfo, and JWKS.
+- Custom Auth Server with OAuth2 authorization code + PKCE, client credentials, optional Entra federated sign-in, OIDC discovery, UserInfo, and JWKS.
 - API Server that validates both local Auth Server JWTs and Microsoft Entra ID access tokens.
-- React SPA with local sign-in, MSAL-based Entra sign-in, Token Inspector, and server-side claims inspection.
+- React SPA with local sign-in, Auth Server federated SSO, MSAL-based Entra sign-in, logout, Token Inspector, and server-side claims inspection.
 - Authorization policies for scopes, roles, service tokens, and API keys.
 - RSA-backed JWT signing with public-key discovery through JWKS.
 - Configurable Entra tenant, audience, client, and issuer validation settings.
@@ -20,13 +20,14 @@ The project focuses on the parts that matter in production systems: token issuan
 flowchart LR
     Browser[React SPA] -->|Authorization Code + PKCE| LocalIdP[AuthFlowLab Auth Server]
     Browser -->|MSAL Authorization Code + PKCE| Entra[Microsoft Entra ID]
+    LocalIdP -->|Optional federated OIDC login| Entra
     LocalIdP -->|Local issuer + JWKS| Api[AuthFlowLab API Server]
     Entra -->|Entra issuer + JWKS| Api
     Browser -->|Bearer access_token| Api
     Browser -->|Graph access token| Graph[Microsoft Graph /me]
 ```
 
-The API Server uses a policy scheme to route bearer tokens to either `LocalJwt` or `EntraJwt`. Local tokens are validated from the Auth Server discovery document and JWKS; Entra tokens are validated from Microsoft discovery metadata and tenant signing keys.
+The API Server uses a policy scheme to route bearer tokens to either `LocalJwt` or `EntraJwt`. Local tokens are validated from the Auth Server discovery document and JWKS; Entra tokens are validated from Microsoft discovery metadata and tenant signing keys. In the federated SSO flow, Entra authenticates the user, but the Auth Server maps that external identity to local users, scopes, and roles before issuing first-party tokens.
 
 ## Key Concepts
 
@@ -44,7 +45,7 @@ The API Server uses a policy scheme to route bearer tokens to either `LocalJwt` 
 
 | Concept | Local Auth Server | Microsoft Entra ID |
 | --- | --- | --- |
-| Identity provider | `AuthFlowLab.AuthServer` | Microsoft Entra tenant |
+| Identity provider | `AuthFlowLab.AuthServer`, optionally federated to Entra | Microsoft Entra tenant |
 | Browser client | `demo-spa` configured locally | SPA app registration |
 | Protected API | `aud=api-server` | API app registration |
 | Issuer | Local Auth Server URL | `login.microsoftonline.com` |
@@ -68,6 +69,27 @@ sequenceDiagram
     Auth-->>Browser: access_token and id_token
     Browser->>Api: API request with local bearer token
     Api->>Auth: Load discovery metadata and JWKS
+    Api-->>Browser: Authorized response
+```
+
+Local authorization code + Entra federated login:
+
+```mermaid
+sequenceDiagram
+    participant Browser as React SPA
+    participant Auth as AuthFlowLab Auth Server
+    participant Entra as Microsoft Entra ID
+    participant Api as AuthFlowLab API Server
+
+    Browser->>Auth: /connect/authorize with code_challenge
+    Auth-->>Browser: Login page with local and Microsoft options
+    Browser->>Entra: Choose Microsoft sign-in
+    Entra-->>Auth: OIDC callback after enterprise login
+    Auth->>Auth: Map Entra user to local user and scopes
+    Auth-->>Browser: Redirect to /callback with local authorization code
+    Browser->>Auth: /connect/token with code_verifier
+    Auth-->>Browser: AuthFlowLab access_token and id_token
+    Browser->>Api: API request with local bearer token
     Api-->>Browser: Authorized response
 ```
 
@@ -115,8 +137,8 @@ docker compose up --build
 Local backend:
 
 ```powershell
-dotnet run --project backend\AuthFlowLab.AuthServer\AuthFlowLab.AuthServer.csproj --urls http://127.0.0.1:5001
-dotnet run --project backend\AuthFlowLab.ApiServer\AuthFlowLab.ApiServer.csproj --urls http://127.0.0.1:5002
+dotnet run --project backend\AuthFlowLab.AuthServer\AuthFlowLab.AuthServer.csproj --urls http://localhost:5001
+dotnet run --project backend\AuthFlowLab.ApiServer\AuthFlowLab.ApiServer.csproj --urls http://localhost:5002
 ```
 
 Local frontend:
@@ -154,9 +176,24 @@ The repository uses local demo Microsoft Entra registrations for a protected API
 | --- | --- |
 | Tenant | `976c3c85-e425-4880-a658-3653df9cebf2` |
 | Redirect URI | `http://localhost:5173/callback` |
-| API scopes | `access_as_user`, `write_as_user` |
+| API scopes | `access_as_user`; `write_as_user` is optional for direct Entra write tests |
 
-The API accepts local `content.read` / `content.write` scopes and Entra `access_as_user` / `write_as_user` scopes for the corresponding read and write endpoints.
+The API accepts local `content.read` / `content.write` scopes and Entra `access_as_user` / `write_as_user` scopes for the corresponding read and write endpoints. The current SPA direct Entra configuration requests only `access_as_user` so the demo works even when the optional Entra write scope has not been created.
+
+Auth Server can also use Entra as an external login provider. In that mode the browser still starts the normal local `/connect/authorize` flow, but the Auth Server offers a Microsoft sign-in option, maps the Entra user back to a local `Auth:Users` entry, then issues its own AuthFlowLab tokens.
+
+External Entra login is disabled by default in the base configuration. To enable it, register a confidential web app in Entra ID and set:
+
+```powershell
+$env:Auth__ExternalProviders__Entra__Enabled = "true"
+$env:Auth__ExternalProviders__Entra__Authority = "https://login.microsoftonline.com/<tenant-id>/v2.0"
+$env:Auth__ExternalProviders__Entra__ClientId = "<auth-server-web-app-client-id>"
+$env:Auth__ExternalProviders__Entra__ClientSecret = "<client-secret>"
+```
+
+Use `http://localhost:5001/signin-entra` as the Entra redirect URI. The Entra username claim, by default `preferred_username`, must match a local `Auth:Users[*].Username` value so the Auth Server can assign local scopes and roles.
+
+Logout clears the SPA token cache and calls Auth Server `/account/logout` so the server-side HttpOnly login cookie is removed. Clearing tokens alone is not a full logout because the Auth Server cookie can still silently produce a new authorization code.
 
 ## API Surface
 
@@ -192,6 +229,7 @@ npm run build
 Auth Server:
 
 - `backend/AuthFlowLab.AuthServer/Controllers/AccountController.cs` owns the local sign-in page and HTTP-only login cookie.
+- `backend/AuthFlowLab.AuthServer/Options/EntraExternalLoginOptions.cs` controls the optional Entra federated login provider.
 - `backend/AuthFlowLab.AuthServer/Controllers/ConnectController.cs` owns `/connect/authorize`, `/connect/token`, UserInfo, PKCE validation, scope checks, and code exchange.
 - `backend/AuthFlowLab.AuthServer/Controllers/DiscoveryController.cs` exposes OIDC discovery metadata and JWKS.
 - `backend/AuthFlowLab.AuthServer/Services/JwtService.cs` signs user access tokens, service access tokens, and OIDC ID tokens.

--- a/backend/AuthFlowLab.ApiServer/Properties/launchSettings.json
+++ b/backend/AuthFlowLab.ApiServer/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:5083",
+      "applicationUrl": "http://localhost:5002",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -14,7 +14,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "https://localhost:7094;http://localhost:5083",
+      "applicationUrl": "https://localhost:7094;http://localhost:5002",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/backend/AuthFlowLab.ApiServer/appsettings.Development.json
+++ b/backend/AuthFlowLab.ApiServer/appsettings.Development.json
@@ -6,7 +6,7 @@
     }
   },
   "Jwt": {
-    "Authority": "http://127.0.0.1:5001",
+    "Authority": "http://localhost:5001",
     "Audience": "api-server",
     "RequireHttpsMetadata": false,
     "Entra": {

--- a/backend/AuthFlowLab.AuthServer.Tests/AuthEndpointTests.cs
+++ b/backend/AuthFlowLab.AuthServer.Tests/AuthEndpointTests.cs
@@ -52,6 +52,28 @@ public sealed class AuthEndpointTests : IClassFixture<AuthServerFactory>
     }
 
     [Fact]
+    public async Task LoginPage_WhenEntraExternalLoginDisabled_HidesMicrosoftButton()
+    {
+        var response = await _client.GetAsync("/account/login");
+        var html = await response.Content.ReadAsStringAsync();
+
+        response.EnsureSuccessStatusCode();
+        Assert.DoesNotContain("Sign in with Microsoft", html);
+    }
+
+    [Fact]
+    public async Task ExternalLogin_WhenEntraExternalLoginDisabled_ReturnsNotFound()
+    {
+        var response = await _client.PostAsync("/account/external-login", new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["provider"] = "Entra",
+            ["returnUrl"] = "/connect/authorize"
+        }));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
     public async Task Login_Returns_AdminWriteScope()
     {
         var response = await _client.PostAsJsonAsync("/auth/login", new
@@ -449,7 +471,8 @@ public sealed class AuthServerFactory : WebApplicationFactory<Program>
                 ["Auth:Clients:1:Scopes:1"] = "profile",
                 ["Auth:Clients:1:Scopes:2"] = "content.read",
                 ["Auth:Clients:1:Scopes:3"] = "content.write",
-                ["Auth:Clients:1:RedirectUris:0"] = "http://127.0.0.1:5173/callback"
+                ["Auth:Clients:1:RedirectUris:0"] = "http://127.0.0.1:5173/callback",
+                ["Auth:ExternalProviders:Entra:Enabled"] = "false"
             });
         });
     }

--- a/backend/AuthFlowLab.AuthServer/AuthFlowLab.AuthServer.csproj
+++ b/backend/AuthFlowLab.AuthServer/AuthFlowLab.AuthServer.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />

--- a/backend/AuthFlowLab.AuthServer/AuthFlowLab.AuthServer.csproj
+++ b/backend/AuthFlowLab.AuthServer/AuthFlowLab.AuthServer.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>6fcf2dcc-6286-41cc-8f3b-4f9f31657966</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/backend/AuthFlowLab.AuthServer/Controllers/AccountController.cs
+++ b/backend/AuthFlowLab.AuthServer/Controllers/AccountController.cs
@@ -12,12 +12,19 @@ namespace AuthFlowLab.AuthServer.Controllers;
 [Route("account")]
 public sealed class AccountController : Controller
 {
+    private const string EntraExternalScheme = "Entra";
+
     private readonly AuthOptions _authOptions;
+    private readonly EntraExternalLoginOptions _entraExternalLoginOptions;
     private readonly HtmlEncoder _htmlEncoder;
 
-    public AccountController(IOptions<AuthOptions> authOptions, HtmlEncoder htmlEncoder)
+    public AccountController(
+        IOptions<AuthOptions> authOptions,
+        IOptions<EntraExternalLoginOptions> entraExternalLoginOptions,
+        HtmlEncoder htmlEncoder)
     {
         _authOptions = authOptions.Value;
+        _entraExternalLoginOptions = entraExternalLoginOptions.Value;
         _htmlEncoder = htmlEncoder;
     }
 
@@ -65,6 +72,27 @@ public sealed class AccountController : Controller
         return LocalRedirect(SanitizeReturnUrl(returnUrl));
     }
 
+    [HttpPost("external-login")]
+    [Consumes("application/x-www-form-urlencoded")]
+    public IActionResult ExternalLogin(
+        [FromForm] string provider,
+        [FromForm] string? returnUrl = null)
+    {
+        // 中文注释：外部登录入口只接受当前支持的 Entra provider，并且必须先确认配置完整。
+        if (!IsEntraLoginEnabled() || provider != EntraExternalScheme)
+        {
+            return NotFound();
+        }
+
+        // 中文注释：外部登录只负责认证企业用户；回调成功后仍然写入 Auth Server 自己的登录 cookie。
+        return Challenge(
+            new AuthenticationProperties
+            {
+                RedirectUri = SanitizeReturnUrl(returnUrl)
+            },
+            EntraExternalScheme);
+    }
+
     [HttpPost("logout")]
     public async Task<IActionResult> Logout()
     {
@@ -77,6 +105,17 @@ public sealed class AccountController : Controller
         var encodedReturnUrl = _htmlEncoder.Encode(SanitizeReturnUrl(returnUrl));
         var encodedError = error is null ? string.Empty : _htmlEncoder.Encode(error);
         var errorMarkup = error is null ? string.Empty : $"<div class=\"alert\">{encodedError}</div>";
+        // 中文注释：只有 Entra SSO 可用时才渲染 Microsoft 登录按钮，本地开发默认只显示本地账号登录。
+        var externalLoginMarkup = IsEntraLoginEnabled()
+            ? $$"""
+    <div class="divider"><span>or</span></div>
+    <form method="post" action="/account/external-login">
+      <input type="hidden" name="provider" value="Entra">
+      <input type="hidden" name="returnUrl" value="{{encodedReturnUrl}}">
+      <button type="submit" class="btn-external">Sign in with Microsoft</button>
+    </form>
+"""
+            : string.Empty;
 
         return $$"""
 <!doctype html>
@@ -101,6 +140,10 @@ public sealed class AccountController : Controller
     input:focus { border-color: #86b7fe; outline: 0; box-shadow: 0 0 0 .25rem rgba(13,110,253,.25); }
     button { width: 100%; border: 1px solid #0d6efd; border-radius: .375rem; padding: .5rem .75rem; color: #fff; background: #0d6efd; font: inherit; font-weight: 600; cursor: pointer; }
     button:hover { background: #0b5ed7; }
+    .btn-external { border-color: #495057; background: #fff; color: #212529; }
+    .btn-external:hover { background: #e9ecef; }
+    .divider { display: flex; align-items: center; gap: .75rem; margin: 1rem 0; color: #6c757d; font-size: .8125rem; }
+    .divider::before, .divider::after { content: ""; flex: 1; height: 1px; background: #dee2e6; }
     .eyebrow { margin: 0 0 .25rem; color: #6c757d; font-size: .75rem; font-weight: 700; text-transform: uppercase; }
     .alert { margin-bottom: .875rem; border: 1px solid #f5c2c7; border-radius: .375rem; padding: .625rem .75rem; color: #842029; background: #f8d7da; font-size: .875rem; }
   </style>
@@ -122,6 +165,7 @@ public sealed class AccountController : Controller
       </label>
       <button type="submit">Continue</button>
     </form>
+{{externalLoginMarkup}}
   </main>
 </body>
 </html>
@@ -132,5 +176,14 @@ public sealed class AccountController : Controller
     {
         // 中文注释: 只允许回跳到本站路径，避免登录后被恶意 returnUrl 带到外部网站。
         return Url.IsLocalUrl(returnUrl) ? returnUrl! : "/";
+    }
+
+    private bool IsEntraLoginEnabled()
+    {
+        // 中文注释：只有 Entra 外部登录配置完整时才显示 SSO 入口，避免本地开发缺少 Azure 配置时误触发跳转。
+        return _entraExternalLoginOptions.Enabled &&
+            !string.IsNullOrWhiteSpace(_entraExternalLoginOptions.Authority) &&
+            !string.IsNullOrWhiteSpace(_entraExternalLoginOptions.ClientId) &&
+            !string.IsNullOrWhiteSpace(_entraExternalLoginOptions.ClientSecret);
     }
 }

--- a/backend/AuthFlowLab.AuthServer/Options/EntraExternalLoginOptions.cs
+++ b/backend/AuthFlowLab.AuthServer/Options/EntraExternalLoginOptions.cs
@@ -1,0 +1,26 @@
+namespace AuthFlowLab.AuthServer.Options;
+
+// 这里集中管理 Auth Server 作为客户端去连接 Entra ID 时需要的外部登录配置。
+public sealed class EntraExternalLoginOptions
+{
+    // Enabled=false 时不会显示 Microsoft 登录入口，也不会注册 Entra OIDC handler。
+    public bool Enabled { get; init; }
+
+    // Entra tenant 的 OIDC authority，例如 https://login.microsoftonline.com/{tenant-id}/v2.0。
+    public string Authority { get; init; } = string.Empty;
+
+    // Auth Server 在 Entra 中注册的 Web 应用 client id。
+    public string ClientId { get; init; } = string.Empty;
+
+    // Auth Server 后端安全保存的 client secret，不能放到前端。
+    public string ClientSecret { get; init; } = string.Empty;
+
+    // Entra 登录完成后回调 Auth Server 的地址，必须和 Azure Portal 中配置一致。
+    public string CallbackPath { get; init; } = "/signin-entra";
+
+    // 用哪个 Entra claim 去匹配本地用户，匹配成功后再使用本地 scopes 和 roles。
+    public string UserNameClaim { get; init; } = "preferred_username";
+
+    // 这里只请求登录认证需要的 OIDC scopes，不直接请求业务 API 权限。
+    public List<string> Scopes { get; init; } = ["openid", "profile", "email"];
+}

--- a/backend/AuthFlowLab.AuthServer/Program.cs
+++ b/backend/AuthFlowLab.AuthServer/Program.cs
@@ -1,10 +1,18 @@
+using System.Security.Claims;
 using AuthFlowLab.AuthServer.Options;
 using AuthFlowLab.AuthServer.Services;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 
 const string FrontendCorsPolicy = "Frontend";
+const string EntraExternalScheme = "Entra";
+// 中文注释：启动时读取 Entra 外部登录配置；配置不完整时保持本地登录流程不变。
+var entraExternalLoginOptions = builder.Configuration
+    .GetSection("Auth:ExternalProviders:Entra")
+    .Get<EntraExternalLoginOptions>() ?? new EntraExternalLoginOptions();
 
 builder.Services.AddCors(options =>
 {
@@ -16,7 +24,9 @@ builder.Services.AddCors(options =>
 
         policy.WithOrigins(origins)
             .AllowAnyHeader()
-            .AllowAnyMethod();
+            .AllowAnyMethod()
+            // 中文注释：SPA 调用 /account/logout 时需要携带 Auth Server 的 HttpOnly cookie，后端才能删除登录会话。
+            .AllowCredentials();
     });
 });
 
@@ -39,9 +49,78 @@ builder.Services
 
 builder.Services.AddAuthorization();
 builder.Services.Configure<AuthOptions>(builder.Configuration.GetSection("Auth"));
+builder.Services.Configure<EntraExternalLoginOptions>(builder.Configuration.GetSection("Auth:ExternalProviders:Entra"));
 builder.Services.AddSingleton<RsaKeyService>();
 builder.Services.AddSingleton<JwtService>();
 builder.Services.AddSingleton<AuthorizationCodeStore>();
+
+// 中文注释：只有 SSO 配置完整时才注册 Entra OIDC handler，避免没有 Azure 配置时启动失败或误跳转。
+if (IsEntraExternalLoginConfigured(entraExternalLoginOptions))
+{
+    builder.Services
+        .AddAuthentication()
+        .AddOpenIdConnect(EntraExternalScheme, options =>
+        {
+            // 中文注释：Entra 只负责外部认证，最终登录状态仍写入 Auth Server 自己的 cookie。
+            options.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+            options.Authority = entraExternalLoginOptions.Authority;
+            options.ClientId = entraExternalLoginOptions.ClientId;
+            options.ClientSecret = entraExternalLoginOptions.ClientSecret;
+            options.CallbackPath = entraExternalLoginOptions.CallbackPath;
+            options.ResponseType = "code";
+            options.SaveTokens = false;
+            options.GetClaimsFromUserInfoEndpoint = false;
+
+            // 中文注释：请求 openid/profile/email 用来确认用户身份，业务 API scopes 仍由本地 Auth Server 发 token 时决定。
+            options.Scope.Clear();
+            foreach (var scope in entraExternalLoginOptions.Scopes)
+            {
+                options.Scope.Add(scope);
+            }
+
+            options.Events = new OpenIdConnectEvents
+            {
+                OnTokenValidated = context =>
+                {
+                    // 中文注释：Entra token 验证成功后，把外部用户映射成本地用户，再套用本地系统的权限模型。
+                    var authOptions = context.HttpContext.RequestServices
+                        .GetRequiredService<IOptions<AuthOptions>>()
+                        .Value;
+                    var externalOptions = context.HttpContext.RequestServices
+                        .GetRequiredService<IOptions<EntraExternalLoginOptions>>()
+                        .Value;
+
+                    var externalUserName =
+                        context.Principal?.FindFirstValue(externalOptions.UserNameClaim) ??
+                        context.Principal?.FindFirstValue("email") ??
+                        context.Principal?.FindFirstValue("name");
+
+                    var user = authOptions.Users.FirstOrDefault(user =>
+                        string.Equals(user.Username, externalUserName, StringComparison.OrdinalIgnoreCase));
+
+                    // 中文注释：没有本地用户映射就拒绝登录，避免任意 Entra 用户直接获得本地系统权限。
+                    if (user is null)
+                    {
+                        context.Fail("The Entra user is not mapped to a local AuthFlowLab user.");
+                        return Task.CompletedTask;
+                    }
+
+                    var claims = CreateLocalUserClaims(user);
+                    claims.Add(new Claim("external_provider", "entra"));
+                    if (!string.IsNullOrWhiteSpace(externalUserName))
+                    {
+                        claims.Add(new Claim("external_username", externalUserName));
+                    }
+
+                    // 中文注释：把映射后的本地 claims 写入 cookie，后续 /connect/authorize 会基于这些 claims 发本地 token。
+                    context.Principal = new ClaimsPrincipal(
+                        new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme));
+
+                    return Task.CompletedTask;
+                }
+            };
+        });
+}
 
 var app = builder.Build();
 
@@ -59,5 +138,31 @@ app.MapHealthChecks("/health");
 app.MapControllers();
 
 app.Run();
+
+static List<Claim> CreateLocalUserClaims(AuthUser user)
+{
+    var claims = new List<Claim>
+    {
+        new(ClaimTypes.NameIdentifier, user.Username),
+        new(ClaimTypes.Name, user.Username),
+        new(ClaimTypes.Role, user.Role)
+    };
+
+    foreach (var scope in user.Scopes)
+    {
+        claims.Add(new Claim("scope", scope));
+    }
+
+    return claims;
+}
+
+static bool IsEntraExternalLoginConfigured(EntraExternalLoginOptions options)
+{
+    // 中文注释：SSO 入口默认关闭；只有配置齐全时才注册 Entra OIDC handler，方便本地无 Azure 配置时运行。
+    return options.Enabled &&
+        !string.IsNullOrWhiteSpace(options.Authority) &&
+        !string.IsNullOrWhiteSpace(options.ClientId) &&
+        !string.IsNullOrWhiteSpace(options.ClientSecret);
+}
 
 public partial class Program;

--- a/backend/AuthFlowLab.AuthServer/Properties/launchSettings.json
+++ b/backend/AuthFlowLab.AuthServer/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:5180",
+      "applicationUrl": "http://localhost:5001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -14,7 +14,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "https://localhost:7164;http://localhost:5180",
+      "applicationUrl": "https://localhost:7164;http://localhost:5001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/backend/AuthFlowLab.AuthServer/appsettings.Development.json
+++ b/backend/AuthFlowLab.AuthServer/appsettings.Development.json
@@ -6,7 +6,7 @@
     }
   },
   "Jwt": {
-    "Issuer": "http://127.0.0.1:5001",
+    "Issuer": "http://localhost:5001",
     "Audience": "api-server",
     "KeyId": "auth-flow-lab-key-1",
     "PrivateKeyPath": "../../keys/private.key"
@@ -41,7 +41,18 @@
         "Scopes": [ "openid", "profile", "content.read", "content.write" ],
         "RedirectUris": [ "http://127.0.0.1:5173/callback", "http://localhost:5173/callback" ]
       }
-    ]
+    ],
+    "ExternalProviders": {
+      "Entra": {
+        "Enabled": false,
+        "Authority": "https://login.microsoftonline.com/<tenant-id>/v2.0",
+        "ClientId": "<auth-server-web-app-client-id>",
+        "ClientSecret": "",
+        "CallbackPath": "/signin-entra",
+        "UserNameClaim": "preferred_username",
+        "Scopes": [ "openid", "profile", "email" ]
+      }
+    }
   },
   "Cors": {
     "AllowedOrigins": [ "http://127.0.0.1:5173", "http://localhost:5173" ]

--- a/backend/AuthFlowLab.AuthServer/appsettings.json
+++ b/backend/AuthFlowLab.AuthServer/appsettings.json
@@ -41,7 +41,18 @@
         "Scopes": [ "openid", "profile", "content.read", "content.write" ],
         "RedirectUris": [ "http://127.0.0.1:5173/callback", "http://localhost:5173/callback" ]
       }
-    ]
+    ],
+    "ExternalProviders": {
+      "Entra": {
+        "Enabled": false,
+        "Authority": "https://login.microsoftonline.com/<tenant-id>/v2.0",
+        "ClientId": "<auth-server-web-app-client-id>",
+        "ClientSecret": "",
+        "CallbackPath": "/signin-entra",
+        "UserNameClaim": "preferred_username",
+        "Scopes": [ "openid", "profile", "email" ]
+      }
+    }
   },
   "Cors": {
     "AllowedOrigins": [ "http://127.0.0.1:5173", "http://localhost:5173" ]

--- a/frontend/AuthFlowLab.Web/src/App.tsx
+++ b/frontend/AuthFlowLab.Web/src/App.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
 import { apiServer, authServer } from './config';
 import {
-  clearSession,
   decodeJwtPayload,
   getApiToken,
   getGraphAccessToken,
   initializeAuthState,
+  logoutSession,
   readTokens,
   startEntraLogin,
   startLogin
@@ -125,18 +125,19 @@ export function App() {
     await callApi(`${authServer}/connect/userinfo`, 'AuthServer /connect/userinfo');
   }
 
-  function logout() {
-    clearSession();
+  async function logout() {
+    // 中文注释：Logout 同时清除前端 token 和 Auth Server cookie，下一次 Local Login 才会重新显示登录页。
+    await logoutSession();
     setTokens(null);
     setResult(null);
-    setMessage('Logged out locally.');
+    setMessage('Logged out.');
   }
 
   return (
     <main className="app-shell">
       <LoginPanel
         message={message}
-        onClear={logout}
+        onLogout={() => void logout()}
         onEntraLogin={() => void handleEntraLogin()}
         onLogin={() => void handleLogin()}
       />

--- a/frontend/AuthFlowLab.Web/src/auth.ts
+++ b/frontend/AuthFlowLab.Web/src/auth.ts
@@ -191,6 +191,16 @@ export function clearSession() {
   void msalReady.then(() => msalInstance.clearCache());
 }
 
+export async function logoutSession() {
+  // 中文注释：完整退出要让 Auth Server 删除 HttpOnly cookie；只清 token 不会清掉 IdP 登录会话。
+  await fetch(`${authServer}/account/logout`, {
+    method: 'POST',
+    credentials: 'include'
+  });
+
+  clearSession();
+}
+
 export function readTokens() {
   return readJson<TokenResponse>(storageKeys.tokens);
 }

--- a/frontend/AuthFlowLab.Web/src/components/LoginPanel.tsx
+++ b/frontend/AuthFlowLab.Web/src/components/LoginPanel.tsx
@@ -2,14 +2,14 @@ type LoginPanelProps = {
   message: string;
   onLogin: () => void;
   onEntraLogin: () => void;
-  onClear: () => void;
+  onLogout: () => void;
 };
 
 export function LoginPanel({
   message,
   onLogin,
   onEntraLogin,
-  onClear
+  onLogout
 }: LoginPanelProps) {
   return (
     <section className="card login-card">
@@ -29,8 +29,8 @@ export function LoginPanel({
         <button type="button" className="btn btn-primary" onClick={onEntraLogin}>
           Entra Login
         </button>
-        <button type="button" className="btn btn-outline" onClick={onClear}>
-          Clear
+        <button type="button" className="btn btn-outline" onClick={onLogout}>
+          Logout
         </button>
       </div>
 

--- a/frontend/AuthFlowLab.Web/src/config.ts
+++ b/frontend/AuthFlowLab.Web/src/config.ts
@@ -1,5 +1,5 @@
-export const authServer = 'http://127.0.0.1:5001';
-export const apiServer = 'http://127.0.0.1:5002';
+export const authServer = 'http://localhost:5001';
+export const apiServer = 'http://localhost:5002';
 
 // Local AuthFlowLab IdP public client. SPA clients do not store client_secret.
 export const clientId = 'demo-spa';
@@ -11,9 +11,9 @@ export const entra = {
   clientId: '35b46efc-ba76-4940-bc2a-a4fa1b904dcb',
   authority: 'https://login.microsoftonline.com/976c3c85-e425-4880-a658-3653df9cebf2/v2.0',
   redirectUri: 'http://localhost:5173/callback',
+  // 中文注释：当前 Azure API 只暴露 read scope；Direct Entra Login 暂时只请求读权限，避免缺少 write_as_user scope 导致登录失败。
   apiScopes: [
-    'api://b5b7fdde-0835-4e46-863d-463b1432e9f7/access_as_user',
-    'api://b5b7fdde-0835-4e46-863d-463b1432e9f7/write_as_user'
+    'api://b5b7fdde-0835-4e46-863d-463b1432e9f7/access_as_user'
   ],
   graphScopes: ['User.Read']
 } as const;


### PR DESCRIPTION
## Summary
- Adds optional Microsoft Entra federated SSO to the local AuthFlowLab Auth Server.
- Maps Entra identities back to local users, scopes, and roles before issuing AuthFlowLab tokens.
- Replaces the frontend Clear action with Logout that clears local token state and the Auth Server HttpOnly cookie.
- Documents the SSO flow, localhost redirect URI, direct Entra read-scope behavior, and configuration steps.

## Validation
- dotnet test backend/AuthFlowLab.sln
- npm run build

## Notes
- Real Entra client secrets are intentionally not committed. Configure `Auth__ExternalProviders__Entra__ClientSecret` through environment variables or user secrets for local testing.
