### PR TITLE
Clarify README login paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,28 @@ In the SSO flow, Entra ID only proves who the user is. AuthFlowLab still decides
 
 ```mermaid
 flowchart LR
-    SPA[React SPA] -->|Local Login / PKCE| Auth[AuthFlowLab Auth Server]
-    Auth -->|Optional SSO| Entra[Microsoft Entra ID]
-    SPA -->|Direct Entra Login| Entra
-    Auth -->|Local JWT + JWKS| API[AuthFlowLab API Server]
-    Entra -->|Entra JWT + JWKS| API
-    Worker[worker-service] -->|client_credentials| Auth
+    subgraph InteractiveUserLogin[Interactive user login]
+        SPA[React SPA]
+        Auth[AuthFlowLab Auth Server]
+        Entra[Microsoft Entra ID]
+        SPA -->|Local Login: authorization code + PKCE| Auth
+        Auth -->|SSO option on login page| Entra
+        Entra -->|OIDC callback to /signin-entra| Auth
+        SPA -->|Direct Entra Login with MSAL| Entra
+    end
+
+    subgraph ServiceToService[Service-to-service]
+        Worker[worker-service]
+        Worker -->|client_credentials only, no SSO| Auth
+    end
+
+    Auth -->|AuthFlowLab JWT + JWKS| API[AuthFlowLab API Server]
+    Entra -->|Direct Entra JWT + JWKS| API
     SPA -->|Bearer token| API
-    Worker -->|Bearer token| API
+    Worker -->|Service bearer token| API
 ```
+
+SSO is only part of the interactive user login path. Background services use `client_credentials` and do not redirect to Entra for user SSO.
 
 ## Authorization Model
 


### PR DESCRIPTION
## Summary
- Clarifies the README architecture diagram so interactive SSO and service-to-service client credentials are separate paths.
- Explicitly notes that worker-service uses client_credentials only and does not participate in SSO.

## Validation
- dotnet test backend/AuthFlowLab.sln
- npm run build
