### PR TITLE
Add BFF login flow and CSRF protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The project is designed to show how identity systems are typically split in ente
 - Custom Auth Server with OAuth2 authorization code + PKCE, client credentials, OIDC discovery, UserInfo, and JWKS.
 - Federated SSO from the Auth Server to Microsoft Entra ID.
 - API Server that accepts both local Auth Server JWTs and direct Entra ID access tokens.
+- BFF backend that stores user access tokens server-side and exposes an HttpOnly session cookie to the browser.
 - React SPA with local login, Auth Server SSO login, direct Entra login, logout, token inspection, and claims inspection.
 - Authorization policies for user scopes, roles, service tokens, and API keys.
 - RSA-backed JWT signing with public-key discovery through JWKS.
@@ -22,6 +23,7 @@ The project is designed to show how identity systems are typically split in ente
 | Auth Server SSO | SPA -> Auth Server -> Entra -> Auth Server -> API | AuthFlowLab access token | Entra identifies the user; Auth Server maps to local scopes/roles |
 | Direct Entra Login | SPA -> Entra -> API | Entra access token | Entra API scopes such as `access_as_user` |
 | Client Credentials | Service -> Auth Server -> API | AuthFlowLab service token | Registered local service client scopes |
+| BFF Login | Browser -> BFF -> Auth Server -> BFF -> API | AuthFlowLab access token stored by BFF | Local `Auth:Users` + `demo-bff` client |
 
 In the SSO flow, Entra ID only proves who the user is. AuthFlowLab still decides what the user can do by mapping the Entra username claim to a local user record and issuing first-party tokens with local scopes and roles.
 
@@ -71,6 +73,26 @@ flowchart LR
 
 The worker-service path is local Auth Server only. It does not use Entra, does not redirect to SSO, and does not represent a signed-in user. API key access is also supported, but it is kept out of the main architecture flow because it is a separate non-OAuth authentication path.
 
+## BFF Backend Flow
+
+```mermaid
+flowchart LR
+    Browser[Browser]
+    BFF[AuthFlowLab BFF]
+    Auth[AuthFlowLab Auth Server]
+    API[AuthFlowLab API Server]
+
+    Browser -->|E1 GET /bff/login| BFF
+    BFF -->|E2 authorization code + PKCE| Auth
+    Auth -->|E3 callback with code| BFF
+    BFF -->|E4 code + verifier + client secret| Auth
+    Auth -->|E5 access token| BFF
+    Browser -->|E6 HttpOnly session cookie| BFF
+    BFF -->|E7 bearer token| API
+```
+
+The BFF stores access tokens in a server-side in-memory session. The browser receives only `AuthFlowLab.Bff.Session`, an HttpOnly cookie containing a random session identifier. The SPA exposes a separate BFF login mode and routes read, claims, write, and UserInfo requests through the BFF. Write requests require an `X-CSRF-TOKEN` header obtained from the BFF session endpoint.
+
 ## Authorization Model
 
 Local AuthFlowLab tokens use the `scope` claim:
@@ -106,6 +128,7 @@ Local backend:
 ```powershell
 dotnet run --project backend\AuthFlowLab.AuthServer\AuthFlowLab.AuthServer.csproj --urls http://localhost:5001
 dotnet run --project backend\AuthFlowLab.ApiServer\AuthFlowLab.ApiServer.csproj --urls http://localhost:5002
+dotnet run --project backend\AuthFlowLab.Bff\AuthFlowLab.Bff.csproj --urls http://localhost:5003
 ```
 
 Local frontend:
@@ -126,6 +149,7 @@ Open `http://localhost:5173`.
 | User | `admin` | `admin123` | `content.read content.write`, `Admin` role |
 | Client | `worker-service` | `worker-secret` | `content.read content.write` |
 | SPA | `demo-spa` | none | `openid profile content.read content.write` |
+| BFF | `demo-bff` | `bff-secret` | `openid profile content.read content.write` |
 | API key | `internal-tool` | `dev-api-key-123` | `X-Api-Key` |
 
 These are development credentials for the local environment. Do not use committed secrets for production systems.
@@ -154,7 +178,7 @@ The Entra username claim, by default `preferred_username`, must match a local `A
 
 ## Logout
 
-The SPA `Logout` action clears local token state and calls Auth Server `/account/logout` to remove the server-side HttpOnly login cookie. Clearing only browser tokens is not enough because an existing Auth Server cookie can still issue a fresh authorization code.
+The SPA `Logout` action clears local token state, removes the BFF token session, and calls Auth Server `/account/logout` to remove the server-side HttpOnly login cookie. Clearing only browser tokens is not enough because an existing Auth Server cookie can still issue a fresh authorization code.
 
 ## API Surface
 
@@ -169,6 +193,19 @@ The SPA `Logout` action clears local token state and calls Auth Server `/account
 | `GET /content/service` | `token_type=service` |
 | `GET /content/api-key` | Valid `X-Api-Key` header |
 | `GET /health` | Service health probe |
+
+BFF endpoints:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /bff/login` | Start BFF authorization-code login |
+| `GET /bff/callback` | Exchange the authorization code server-side |
+| `GET /bff/session` | Return BFF session status without exposing the access token |
+| `GET /bff/content/read` | Proxy a read request to API Server |
+| `GET /bff/content/me` | Proxy the API Server claims inspection request |
+| `POST /bff/content/write` | Proxy a write request with `X-CSRF-TOKEN` validation |
+| `GET /bff/userinfo` | Proxy the Auth Server UserInfo request |
+| `POST /bff/logout` | Delete the BFF token session and HttpOnly cookie |
 
 HTTP request examples are available in:
 
@@ -204,3 +241,8 @@ Frontend:
 - `frontend/AuthFlowLab.Web/src/auth.ts` handles PKCE, callback exchange, MSAL login, token acquisition, and logout state cleanup.
 - `frontend/AuthFlowLab.Web/src/App.tsx` coordinates login state, API calls, claims inspection, and logout.
 - `frontend/AuthFlowLab.Web/src/config.ts` centralizes local URLs, client ID, redirect URI, scopes, and storage keys.
+
+BFF:
+
+- `backend/AuthFlowLab.Bff/Controllers/BffController.cs` owns login, callback, session inspection, API proxies, CSRF validation, and logout.
+- `backend/AuthFlowLab.Bff/Services/BffSessionStore.cs` stores temporary PKCE state and server-side token sessions in memory.

--- a/backend/AuthFlowLab.ApiServer.Tests/ContentEndpointTests.cs
+++ b/backend/AuthFlowLab.ApiServer.Tests/ContentEndpointTests.cs
@@ -98,7 +98,7 @@ public sealed class ContentEndpointTests : IClassFixture<ApiServerFactory>
     [Fact]
     public async Task ReadContent_AllowsEntraJwtBearerToken()
     {
-        // 中文注释：这个 token 使用 Entra issuer/audience 和独立签名 key，只配置给 EntraJwt scheme。
+        // 这个 token 使用 Entra issuer/audience 和独立签名 key，只配置给 EntraJwt scheme。
         // 如果请求成功，说明 SmartBearer 正确分流到了 EntraJwt，而不是误走 LocalJwt。
         UseBearerToken(_factory.CreateEntraToken("entra-user", scp: "access_as_user"));
 
@@ -251,7 +251,7 @@ public sealed class ApiServerFactory : WebApplicationFactory<Program>
             new("name", "Entra Test User")
         };
 
-        // 中文注释：这里模拟 Entra ID access token 的关键字段，重点覆盖 issuer、audience 和 scp。
+        // 这里模拟 Entra ID access token 的关键字段，重点覆盖 issuer、audience 和 scp。
         var token = new JwtSecurityToken(
             issuer: "https://login.microsoftonline.com/976c3c85-e425-4880-a658-3653df9cebf2/v2.0",
             audience: "api://b5b7fdde-0835-4e46-863d-463b1432e9f7",
@@ -310,7 +310,7 @@ public sealed class ApiServerFactory : WebApplicationFactory<Program>
                     KeyId = "entra-test-key"
                 };
 
-                // 中文注释：测试环境不访问 Microsoft discovery endpoint，直接注入模拟的 Entra JWKS 配置。
+                // 测试环境不访问 Microsoft discovery endpoint，直接注入模拟的 Entra JWKS 配置。
                 options.Configuration = new OpenIdConnectConfiguration
                 {
                     Issuer = "https://login.microsoftonline.com/976c3c85-e425-4880-a658-3653df9cebf2/v2.0"

--- a/backend/AuthFlowLab.ApiServer/Authentication/ApiKeyAuthenticationHandler.cs
+++ b/backend/AuthFlowLab.ApiServer/Authentication/ApiKeyAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;
@@ -17,7 +17,7 @@ public sealed class ApiKeyAuthenticationHandler : AuthenticationHandler<ApiKeyAu
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        // 中文注释: API key 由 ApiServer 本地校验，不调用 AuthServer，也不生成 JWT。
+        //  API key 由 ApiServer 本地校验，不调用 AuthServer，也不生成 JWT。
         if (!Request.Headers.TryGetValue(ApiKeyAuthenticationDefaults.HeaderName, out var headerValues))
         {
             return Task.FromResult(AuthenticateResult.NoResult());
@@ -35,7 +35,7 @@ public sealed class ApiKeyAuthenticationHandler : AuthenticationHandler<ApiKeyAu
             return Task.FromResult(AuthenticateResult.Fail("The API key is invalid."));
         }
 
-        // 中文注释: 认证成功后把 API key 身份转成 ClaimsPrincipal，供授权策略继续判断。
+        //  认证成功后把 API key 身份转成 ClaimsPrincipal，供授权策略继续判断。
         var claims = new[]
         {
             new Claim(ClaimTypes.NameIdentifier, credential.Name),

--- a/backend/AuthFlowLab.AuthServer.Tests/AuthEndpointTests.cs
+++ b/backend/AuthFlowLab.AuthServer.Tests/AuthEndpointTests.cs
@@ -381,6 +381,50 @@ public sealed class AuthEndpointTests : IClassFixture<AuthServerFactory>
         Assert.Equal("invalid_grant", error?.Error);
     }
 
+    [Fact]
+    public async Task Token_WithAuthorizationCode_ForConfidentialBffRequiresClientSecret()
+    {
+        var verifier = "test-bff-code-verifier-1234567890";
+        var code = await CreateBffAuthorizationCode(verifier);
+
+        var response = await _client.PostAsync("/connect/token", new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "authorization_code",
+            ["client_id"] = "demo-bff",
+            ["code"] = code,
+            ["redirect_uri"] = "http://localhost:5003/bff/callback",
+            ["code_verifier"] = verifier
+        }));
+
+        var error = await response.Content.ReadFromJsonAsync<AuthErrorResponse>();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal("invalid_client", error?.Error);
+    }
+
+    [Fact]
+    public async Task Token_WithAuthorizationCode_ForConfidentialBffAcceptsClientSecret()
+    {
+        var verifier = "test-bff-code-verifier-1234567890";
+        var code = await CreateBffAuthorizationCode(verifier);
+
+        var response = await _client.PostAsync("/connect/token", new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "authorization_code",
+            ["client_id"] = "demo-bff",
+            ["client_secret"] = "bff-secret",
+            ["code"] = code,
+            ["redirect_uri"] = "http://localhost:5003/bff/callback",
+            ["code_verifier"] = verifier
+        }));
+
+        response.EnsureSuccessStatusCode();
+        var token = await response.Content.ReadFromJsonAsync<TokenResponse>();
+
+        Assert.NotNull(token);
+        Assert.False(string.IsNullOrWhiteSpace(token.AccessToken));
+    }
+
     private async Task<string> CreateAuthorizationCode(
         string verifier,
         string scope = "content.read",
@@ -419,6 +463,29 @@ public sealed class AuthEndpointTests : IClassFixture<AuthServerFactory>
         }));
 
         Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+    }
+
+    private async Task<string> CreateBffAuthorizationCode(string verifier)
+    {
+        await SignInOnAuthServer();
+
+        var authorizeUrl = QueryHelpers.AddQueryString("/connect/authorize", new Dictionary<string, string?>
+        {
+            ["response_type"] = "code",
+            ["client_id"] = "demo-bff",
+            ["redirect_uri"] = "http://localhost:5003/bff/callback",
+            ["scope"] = "openid profile content.read",
+            ["state"] = "bff-state",
+            ["nonce"] = "bff-nonce",
+            ["code_challenge"] = CreateS256Challenge(verifier),
+            ["code_challenge_method"] = "S256"
+        });
+
+        var response = await _client.GetAsync(authorizeUrl);
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+
+        var callbackQuery = QueryHelpers.ParseQuery(response.Headers.Location!.Query);
+        return callbackQuery["code"].ToString();
     }
 
     private static string CreateS256Challenge(string verifier)
@@ -472,6 +539,14 @@ public sealed class AuthServerFactory : WebApplicationFactory<Program>
                 ["Auth:Clients:1:Scopes:2"] = "content.read",
                 ["Auth:Clients:1:Scopes:3"] = "content.write",
                 ["Auth:Clients:1:RedirectUris:0"] = "http://127.0.0.1:5173/callback",
+                ["Auth:Clients:2:ClientId"] = "demo-bff",
+                ["Auth:Clients:2:ClientSecret"] = "bff-secret",
+                ["Auth:Clients:2:AllowedGrantTypes:0"] = "authorization_code",
+                ["Auth:Clients:2:Scopes:0"] = "openid",
+                ["Auth:Clients:2:Scopes:1"] = "profile",
+                ["Auth:Clients:2:Scopes:2"] = "content.read",
+                ["Auth:Clients:2:Scopes:3"] = "content.write",
+                ["Auth:Clients:2:RedirectUris:0"] = "http://localhost:5003/bff/callback",
                 ["Auth:ExternalProviders:Entra:Enabled"] = "false"
             });
         });

--- a/backend/AuthFlowLab.AuthServer/Controllers/AccountController.cs
+++ b/backend/AuthFlowLab.AuthServer/Controllers/AccountController.cs
@@ -1,4 +1,4 @@
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using System.Text.Encodings.Web;
 using AuthFlowLab.AuthServer.Models;
 using AuthFlowLab.AuthServer.Options;
@@ -31,7 +31,7 @@ public sealed class AccountController : Controller
     [HttpGet("login")]
     public IActionResult Login([FromQuery] string? returnUrl = null)
     {
-        // 中文注释: 登录页由 Auth Server 自己展示，SPA 不再收集或传递用户密码。
+        //  登录页由 Auth Server 自己展示，SPA 不再收集或传递用户密码。
         return Content(RenderLoginPage(returnUrl, null), "text/html; charset=utf-8");
     }
 
@@ -47,7 +47,7 @@ public sealed class AccountController : Controller
 
         if (user is null)
         {
-            // 中文注释: 登录页认证失败时只重新显示表单，不把密码写入 URL 或日志。
+            //  登录页认证失败时只重新显示表单，不把密码写入 URL 或日志。
             return Content(RenderLoginPage(returnUrl, "The username or password is invalid."), "text/html; charset=utf-8");
         }
 
@@ -63,7 +63,7 @@ public sealed class AccountController : Controller
             claims.Add(new Claim("scope", scope));
         }
 
-        // 中文注释: 登录成功只写入 HttpOnly cookie；真正给 SPA 的 token 仍然要走 /connect/token。
+        //  登录成功只写入 HttpOnly cookie；真正给 SPA 的 token 仍然要走 /connect/token。
         var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
         await HttpContext.SignInAsync(
             CookieAuthenticationDefaults.AuthenticationScheme,
@@ -78,13 +78,13 @@ public sealed class AccountController : Controller
         [FromForm] string provider,
         [FromForm] string? returnUrl = null)
     {
-        // 中文注释：外部登录入口只接受当前支持的 Entra provider，并且必须先确认配置完整。
+        // 外部登录入口只接受当前支持的 Entra provider，并且必须先确认配置完整。
         if (!IsEntraLoginEnabled() || provider != EntraExternalScheme)
         {
             return NotFound();
         }
 
-        // 中文注释：外部登录只负责认证企业用户；回调成功后仍然写入 Auth Server 自己的登录 cookie。
+        // 外部登录只负责认证企业用户；回调成功后仍然写入 Auth Server 自己的登录 cookie。
         return Challenge(
             new AuthenticationProperties
             {
@@ -105,7 +105,7 @@ public sealed class AccountController : Controller
         var encodedReturnUrl = _htmlEncoder.Encode(SanitizeReturnUrl(returnUrl));
         var encodedError = error is null ? string.Empty : _htmlEncoder.Encode(error);
         var errorMarkup = error is null ? string.Empty : $"<div class=\"alert\">{encodedError}</div>";
-        // 中文注释：只有 Entra SSO 可用时才渲染 Microsoft 登录按钮，本地开发默认只显示本地账号登录。
+        // 只有 Entra SSO 可用时才渲染 Microsoft 登录按钮，本地开发默认只显示本地账号登录。
         var externalLoginMarkup = IsEntraLoginEnabled()
             ? $$"""
     <div class="divider"><span>or</span></div>
@@ -174,13 +174,13 @@ public sealed class AccountController : Controller
 
     private string SanitizeReturnUrl(string? returnUrl)
     {
-        // 中文注释: 只允许回跳到本站路径，避免登录后被恶意 returnUrl 带到外部网站。
+        //  只允许回跳到本站路径，避免登录后被恶意 returnUrl 带到外部网站。
         return Url.IsLocalUrl(returnUrl) ? returnUrl! : "/";
     }
 
     private bool IsEntraLoginEnabled()
     {
-        // 中文注释：只有 Entra 外部登录配置完整时才显示 SSO 入口，避免本地开发缺少 Azure 配置时误触发跳转。
+        // 只有 Entra 外部登录配置完整时才显示 SSO 入口，避免本地开发缺少 Azure 配置时误触发跳转。
         return _entraExternalLoginOptions.Enabled &&
             !string.IsNullOrWhiteSpace(_entraExternalLoginOptions.Authority) &&
             !string.IsNullOrWhiteSpace(_entraExternalLoginOptions.ClientId) &&

--- a/backend/AuthFlowLab.AuthServer/Controllers/ConnectController.cs
+++ b/backend/AuthFlowLab.AuthServer/Controllers/ConnectController.cs
@@ -1,4 +1,4 @@
-using System.Security.Cryptography;
+﻿using System.Security.Cryptography;
 using System.Text;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
@@ -89,7 +89,7 @@ public class ConnectController : ControllerBase
 
         if (User.Identity?.IsAuthenticated != true)
         {
-            // 中文注释: 未登录时跳转到 Auth Server 登录页，保留原始 authorize URL 作为登录后的 returnUrl。
+            //  未登录时跳转到 Auth Server 登录页，保留原始 authorize URL 作为登录后的 returnUrl。
             var returnUrl = Request.PathBase + Request.Path + Request.QueryString;
             var loginUrl = QueryHelpers.AddQueryString("/account/login", "returnUrl", returnUrl);
             return Redirect(loginUrl);
@@ -102,7 +102,7 @@ public class ConnectController : ControllerBase
             return Unauthorized(new AuthErrorResponse("invalid_grant", "The signed-in user is no longer valid."));
         }
 
-        // 中文注释: scope 同时受用户权限和客户端注册权限约束，OIDC scope 不等同于 API 权限。
+        //  scope 同时受用户权限和客户端注册权限约束，OIDC scope 不等同于 API 权限。
         var requestedScopes = ResolveRequestedScopes(scope, user.Scopes);
         if (requestedScopes.Contains("openid", StringComparer.Ordinal) && string.IsNullOrWhiteSpace(nonce))
         {
@@ -119,7 +119,7 @@ public class ConnectController : ControllerBase
 
         var grantedScopes = ResolveGrantedUserScopes(requestedScopes, user, client);
 
-        // 中文注释: 授权码只保存服务端状态，浏览器地址栏只拿到一次性 code 和原始 state。
+        //  授权码只保存服务端状态，浏览器地址栏只拿到一次性 code 和原始 state。
         var code = _authorizationCodeStore.Create(
             client.ClientId,
             redirectUri,
@@ -185,11 +185,11 @@ public class ConnectController : ControllerBase
                 "The grant_type form field is required."));
         }
 
-        // 中文注释: token endpoint 同时承载服务身份的 client_credentials 和用户登录后的 authorization_code。
+        //  token endpoint 同时承载服务身份的 client_credentials 和用户登录后的 authorization_code。
         return grantType switch
         {
             ClientCredentialsGrantType => HandleClientCredentials(clientId, clientSecret, scope),
-            AuthorizationCodeGrantType => HandleAuthorizationCode(clientId, code, redirectUri, codeVerifier),
+            AuthorizationCodeGrantType => HandleAuthorizationCode(clientId, clientSecret, code, redirectUri, codeVerifier),
             _ => BadRequest(new AuthErrorResponse(
                 "unsupported_grant_type",
                 "Only client_credentials and authorization_code are supported by this token endpoint."))
@@ -223,12 +223,13 @@ public class ConnectController : ControllerBase
                 "The requested scope is not allowed for this client."));
         }
 
-        // 中文注释: client_credentials 发的是服务 token，不代表任何用户。
+        //  client_credentials 发的是服务 token，不代表任何用户。
         return Ok(_jwtService.GenerateServiceToken(client.ClientId, requestedScopes));
     }
 
     private IActionResult HandleAuthorizationCode(
         string? clientId,
+        string? clientSecret,
         string? code,
         string? redirectUri,
         string? codeVerifier)
@@ -250,6 +251,13 @@ public class ConnectController : ControllerBase
             return BadRequest(new AuthErrorResponse("unauthorized_client", "The client cannot use authorization_code."));
         }
 
+        // SPA 是没有 secret 的 public client；BFF 是 confidential client，换 token 时必须同时校验 client_secret。
+        if (!string.IsNullOrWhiteSpace(client.ClientSecret) &&
+            !string.Equals(client.ClientSecret, clientSecret, StringComparison.Ordinal))
+        {
+            return Unauthorized(new AuthErrorResponse("invalid_client", "The client id or secret is invalid."));
+        }
+
         if (string.IsNullOrWhiteSpace(code) ||
             !_authorizationCodeStore.TryConsume(code, out var authorizationCode) ||
             authorizationCode is null)
@@ -267,7 +275,7 @@ public class ConnectController : ControllerBase
             return BadRequest(new AuthErrorResponse("invalid_grant", "The PKCE code_verifier is invalid."));
         }
 
-        // 中文注释: code、redirect_uri、client_id、PKCE 全部校验后，才签发用户 access_token/id_token。
+        //  code、redirect_uri、client_id、PKCE 全部校验后，才签发用户 access_token/id_token。
         return Ok(_jwtService.GenerateUserToken(
             authorizationCode.Username,
             authorizationCode.Role,
@@ -343,7 +351,7 @@ public class ConnectController : ControllerBase
         var handler = new JwtSecurityTokenHandler();
         try
         {
-            // 中文注释: UserInfo 复用本 Auth Server 的签名公钥验证 access_token，避免信任未验证的 JWT 内容。
+            //  UserInfo 复用本 Auth Server 的签名公钥验证 access_token，避免信任未验证的 JWT 内容。
             return handler.ValidateToken(token, new TokenValidationParameters
             {
                 ValidateIssuer = true,

--- a/backend/AuthFlowLab.AuthServer/Controllers/DiscoveryController.cs
+++ b/backend/AuthFlowLab.AuthServer/Controllers/DiscoveryController.cs
@@ -1,4 +1,4 @@
-using AuthFlowLab.AuthServer.Services;
+﻿using AuthFlowLab.AuthServer.Services;
 using Microsoft.AspNetCore.Mvc;
 
 namespace AuthFlowLab.AuthServer.Controllers;
@@ -21,7 +21,7 @@ public sealed class DiscoveryController : ControllerBase
     {
         var issuer = GetIssuer();
 
-        // 中文注释: discovery 文档告诉客户端和 API：authorize/token/userinfo/JWKS 端点在哪里、支持哪些能力。
+        //  discovery 文档告诉客户端和 API：authorize/token/userinfo/JWKS 端点在哪里、支持哪些能力。
         return Ok(new
         {
             issuer,
@@ -42,7 +42,7 @@ public sealed class DiscoveryController : ControllerBase
     [HttpGet("jwks.json")]
     public IActionResult Jwks()
     {
-        // 中文注释: JWKS 只暴露公钥参数，API Server 用它验证 JWT 签名，不需要 public.key 文件。
+        //  JWKS 只暴露公钥参数，API Server 用它验证 JWT 签名，不需要 public.key 文件。
         return Ok(new
         {
             keys = new[] { _rsaKeyService.CreateJsonWebKey() }

--- a/backend/AuthFlowLab.AuthServer/Program.cs
+++ b/backend/AuthFlowLab.AuthServer/Program.cs
@@ -1,4 +1,4 @@
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using AuthFlowLab.AuthServer.Options;
 using AuthFlowLab.AuthServer.Services;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -9,7 +9,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 const string FrontendCorsPolicy = "Frontend";
 const string EntraExternalScheme = "Entra";
-// 中文注释：启动时读取 Entra 外部登录配置；配置不完整时保持本地登录流程不变。
+// 启动时读取 Entra 外部登录配置；配置不完整时保持本地登录流程不变。
 var entraExternalLoginOptions = builder.Configuration
     .GetSection("Auth:ExternalProviders:Entra")
     .Get<EntraExternalLoginOptions>() ?? new EntraExternalLoginOptions();
@@ -25,7 +25,7 @@ builder.Services.AddCors(options =>
         policy.WithOrigins(origins)
             .AllowAnyHeader()
             .AllowAnyMethod()
-            // 中文注释：SPA 调用 /account/logout 时需要携带 Auth Server 的 HttpOnly cookie，后端才能删除登录会话。
+            // SPA 调用 /account/logout 时需要携带 Auth Server 的 HttpOnly cookie，后端才能删除登录会话。
             .AllowCredentials();
     });
 });
@@ -39,7 +39,7 @@ builder.Services
     .AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
     .AddCookie(options =>
     {
-        // 中文注释: Auth Server 用自己的登录 cookie 记录用户是否已经在 IdP 登录。
+        //  Auth Server 用自己的登录 cookie 记录用户是否已经在 IdP 登录。
         options.LoginPath = "/account/login";
         options.Cookie.Name = "AuthFlowLab.Auth";
         options.Cookie.HttpOnly = true;
@@ -54,14 +54,14 @@ builder.Services.AddSingleton<RsaKeyService>();
 builder.Services.AddSingleton<JwtService>();
 builder.Services.AddSingleton<AuthorizationCodeStore>();
 
-// 中文注释：只有 SSO 配置完整时才注册 Entra OIDC handler，避免没有 Azure 配置时启动失败或误跳转。
+// 只有 SSO 配置完整时才注册 Entra OIDC handler，避免没有 Azure 配置时启动失败或误跳转。
 if (IsEntraExternalLoginConfigured(entraExternalLoginOptions))
 {
     builder.Services
         .AddAuthentication()
         .AddOpenIdConnect(EntraExternalScheme, options =>
         {
-            // 中文注释：Entra 只负责外部认证，最终登录状态仍写入 Auth Server 自己的 cookie。
+            // Entra 只负责外部认证，最终登录状态仍写入 Auth Server 自己的 cookie。
             options.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
             options.Authority = entraExternalLoginOptions.Authority;
             options.ClientId = entraExternalLoginOptions.ClientId;
@@ -71,7 +71,7 @@ if (IsEntraExternalLoginConfigured(entraExternalLoginOptions))
             options.SaveTokens = false;
             options.GetClaimsFromUserInfoEndpoint = false;
 
-            // 中文注释：请求 openid/profile/email 用来确认用户身份，业务 API scopes 仍由本地 Auth Server 发 token 时决定。
+            // 请求 openid/profile/email 用来确认用户身份，业务 API scopes 仍由本地 Auth Server 发 token 时决定。
             options.Scope.Clear();
             foreach (var scope in entraExternalLoginOptions.Scopes)
             {
@@ -82,7 +82,7 @@ if (IsEntraExternalLoginConfigured(entraExternalLoginOptions))
             {
                 OnTokenValidated = context =>
                 {
-                    // 中文注释：Entra token 验证成功后，把外部用户映射成本地用户，再套用本地系统的权限模型。
+                    // Entra token 验证成功后，把外部用户映射成本地用户，再套用本地系统的权限模型。
                     var authOptions = context.HttpContext.RequestServices
                         .GetRequiredService<IOptions<AuthOptions>>()
                         .Value;
@@ -98,7 +98,7 @@ if (IsEntraExternalLoginConfigured(entraExternalLoginOptions))
                     var user = authOptions.Users.FirstOrDefault(user =>
                         string.Equals(user.Username, externalUserName, StringComparison.OrdinalIgnoreCase));
 
-                    // 中文注释：没有本地用户映射就拒绝登录，避免任意 Entra 用户直接获得本地系统权限。
+                    // 没有本地用户映射就拒绝登录，避免任意 Entra 用户直接获得本地系统权限。
                     if (user is null)
                     {
                         context.Fail("The Entra user is not mapped to a local AuthFlowLab user.");
@@ -112,7 +112,7 @@ if (IsEntraExternalLoginConfigured(entraExternalLoginOptions))
                         claims.Add(new Claim("external_username", externalUserName));
                     }
 
-                    // 中文注释：把映射后的本地 claims 写入 cookie，后续 /connect/authorize 会基于这些 claims 发本地 token。
+                    // 把映射后的本地 claims 写入 cookie，后续 /connect/authorize 会基于这些 claims 发本地 token。
                     context.Principal = new ClaimsPrincipal(
                         new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme));
 
@@ -130,7 +130,7 @@ app.UseSwaggerUI();
 app.UseHttpsRedirection();
 app.UseCors(FrontendCorsPolicy);
 
-// 中文注释: authorize 端点依赖 cookie 认证先还原 User，再决定是否跳登录页或发授权码。
+//  authorize 端点依赖 cookie 认证先还原 User，再决定是否跳登录页或发授权码。
 app.UseAuthentication();
 app.UseAuthorization();
 
@@ -158,7 +158,7 @@ static List<Claim> CreateLocalUserClaims(AuthUser user)
 
 static bool IsEntraExternalLoginConfigured(EntraExternalLoginOptions options)
 {
-    // 中文注释：SSO 入口默认关闭；只有配置齐全时才注册 Entra OIDC handler，方便本地无 Azure 配置时运行。
+    // SSO 入口默认关闭；只有配置齐全时才注册 Entra OIDC handler，方便本地无 Azure 配置时运行。
     return options.Enabled &&
         !string.IsNullOrWhiteSpace(options.Authority) &&
         !string.IsNullOrWhiteSpace(options.ClientId) &&

--- a/backend/AuthFlowLab.AuthServer/Services/JwtService.cs
+++ b/backend/AuthFlowLab.AuthServer/Services/JwtService.cs
@@ -1,4 +1,4 @@
-using System.IdentityModel.Tokens.Jwt;
+﻿using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using AuthFlowLab.AuthServer.Models;
 using AuthFlowLab.AuthServer.Options;
@@ -33,7 +33,7 @@ public class JwtService
         var scopeList = scopes.ToList();
         var scope = string.Join(' ', scopeList);
 
-        // 中文注释: access_token 面向 API Server，包含用户、角色、scope 和 token_type=user。
+        //  access_token 面向 API Server，包含用户、角色、scope 和 token_type=user。
         var claims = new List<Claim>
         {
             new(JwtRegisteredClaimNames.Sub, username),
@@ -47,7 +47,7 @@ public class JwtService
 
         var accessToken = GenerateJwt(claims, GetApiAudience());
 
-        // 中文注释: 只有请求 openid scope 时才额外签发 id_token，供 SPA 识别登录用户。
+        //  只有请求 openid scope 时才额外签发 id_token，供 SPA 识别登录用户。
         var idToken = scopeList.Contains("openid", StringComparer.Ordinal)
             ? GenerateIdToken(username, role, clientId, nonce)
             : null;
@@ -59,7 +59,7 @@ public class JwtService
     {
         var scope = string.Join(' ', scopes);
 
-        // 中文注释: service token 代表客户端应用自身，适合后台任务或服务间调用。
+        //  service token 代表客户端应用自身，适合后台任务或服务间调用。
         var claims = new List<Claim>
         {
             new(JwtRegisteredClaimNames.Sub, clientId),
@@ -103,7 +103,7 @@ public class JwtService
 
     private string GenerateJwt(List<Claim> claims, string audience)
     {
-        // 中文注释: 所有 JWT 都用 Auth Server 的 RSA 私钥签名；audience 决定 token 给谁使用。
+        //  所有 JWT 都用 Auth Server 的 RSA 私钥签名；audience 决定 token 给谁使用。
         var token = new JwtSecurityToken(
             issuer: GetIssuer(),
             audience: audience,

--- a/backend/AuthFlowLab.AuthServer/Services/RsaKeyService.cs
+++ b/backend/AuthFlowLab.AuthServer/Services/RsaKeyService.cs
@@ -1,4 +1,4 @@
-using System.Security.Cryptography;
+﻿using System.Security.Cryptography;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
@@ -27,7 +27,7 @@ public sealed class RsaKeyService
 
     public SigningCredentials CreateSigningCredentials()
     {
-        // 中文注释: 私钥只留在 Auth Server 内部，用来签名 access_token 和 id_token。
+        //  私钥只留在 Auth Server 内部，用来签名 access_token 和 id_token。
         var signingKey = new RsaSecurityKey(_rsa.Value)
         {
             KeyId = KeyId
@@ -38,7 +38,7 @@ public sealed class RsaKeyService
 
     public JsonWebKey CreateJsonWebKey()
     {
-        // 中文注释: 从同一把 RSA key 导出公钥参数，供 JWKS endpoint 返回给 API Server。
+        //  从同一把 RSA key 导出公钥参数，供 JWKS endpoint 返回给 API Server。
         var parameters = _rsa.Value.ExportParameters(includePrivateParameters: false);
 
         return new JsonWebKey
@@ -66,7 +66,7 @@ public sealed class RsaKeyService
             return LoadPrivateKeyFromFile(privateKeyPath);
         }
 
-        // 中文注释: Docker 或全新开发环境没有本地私钥时，生成临时签名密钥以便实验项目可直接启动。
+        //  Docker 或全新开发环境没有本地私钥时，生成临时签名密钥以便实验项目可直接启动。
         _logger.LogWarning("Private key file '{PrivateKeyPath}' was not found. Using an ephemeral RSA key for this process.", privateKeyPath);
         return RSA.Create(2048);
     }

--- a/backend/AuthFlowLab.AuthServer/appsettings.Development.json
+++ b/backend/AuthFlowLab.AuthServer/appsettings.Development.json
@@ -40,6 +40,13 @@
         "AllowedGrantTypes": [ "authorization_code" ],
         "Scopes": [ "openid", "profile", "content.read", "content.write" ],
         "RedirectUris": [ "http://127.0.0.1:5173/callback", "http://localhost:5173/callback" ]
+      },
+      {
+        "ClientId": "demo-bff",
+        "ClientSecret": "bff-secret",
+        "AllowedGrantTypes": [ "authorization_code" ],
+        "Scopes": [ "openid", "profile", "content.read", "content.write" ],
+        "RedirectUris": [ "http://localhost:5003/bff/callback" ]
       }
     ],
     "ExternalProviders": {

--- a/backend/AuthFlowLab.AuthServer/appsettings.json
+++ b/backend/AuthFlowLab.AuthServer/appsettings.json
@@ -40,6 +40,13 @@
         "AllowedGrantTypes": [ "authorization_code" ],
         "Scopes": [ "openid", "profile", "content.read", "content.write" ],
         "RedirectUris": [ "http://127.0.0.1:5173/callback", "http://localhost:5173/callback" ]
+      },
+      {
+        "ClientId": "demo-bff",
+        "ClientSecret": "bff-secret",
+        "AllowedGrantTypes": [ "authorization_code" ],
+        "Scopes": [ "openid", "profile", "content.read", "content.write" ],
+        "RedirectUris": [ "http://localhost:5003/bff/callback" ]
       }
     ],
     "ExternalProviders": {

--- a/backend/AuthFlowLab.Bff.Tests/AuthFlowLab.Bff.Tests.csproj
+++ b/backend/AuthFlowLab.Bff.Tests/AuthFlowLab.Bff.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AuthFlowLab.Bff\AuthFlowLab.Bff.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/AuthFlowLab.Bff.Tests/BffEndpointTests.cs
+++ b/backend/AuthFlowLab.Bff.Tests/BffEndpointTests.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using AuthFlowLab.Bff.Models;
+using AuthFlowLab.Bff.Services;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AuthFlowLab.Bff.Tests;
+
+public sealed class BffEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+    private readonly BffSessionStore _sessionStore;
+
+    public BffEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+        _sessionStore = factory.Services.GetRequiredService<BffSessionStore>();
+    }
+
+    [Fact]
+    public async Task Health_ReturnsHealthy()
+    {
+        var response = await _client.GetAsync("/health");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_RedirectsToAuthServerAuthorizeEndpoint()
+    {
+        var response = await _client.GetAsync("/bff/login");
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.NotNull(response.Headers.Location);
+        Assert.StartsWith("http://localhost:5001/connect/authorize", response.Headers.Location.ToString());
+        Assert.Contains("client_id=demo-bff", response.Headers.Location.Query);
+        Assert.Contains("code_challenge_method=S256", response.Headers.Location.Query);
+    }
+
+    [Fact]
+    public async Task Session_WhenNotLoggedIn_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync("/bff/session");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReadContent_WhenNotLoggedIn_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync("/bff/content/read");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("/bff/content/me")]
+    [InlineData("/bff/userinfo")]
+    public async Task ReadProxy_WhenNotLoggedIn_ReturnsUnauthorized(string path)
+    {
+        var response = await _client.GetAsync(path);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task WriteContent_WhenNotLoggedIn_ReturnsUnauthorized()
+    {
+        var response = await _client.PostAsync("/bff/content/write", null);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Session_WhenLoggedIn_ReturnsCsrfTokenWithoutAccessToken()
+    {
+        var sessionId = CreateSession();
+        using var request = CreateRequest(HttpMethod.Get, "/bff/session", sessionId);
+
+        var response = await _client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("\"csrfToken\":", body);
+        Assert.DoesNotContain("test-access-token", body);
+    }
+
+    [Fact]
+    public async Task WriteContent_WithoutCsrfToken_ReturnsBadRequest()
+    {
+        var sessionId = CreateSession();
+        using var request = CreateRequest(HttpMethod.Post, "/bff/content/write", sessionId);
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task WriteContent_WithInvalidCsrfToken_ReturnsBadRequest()
+    {
+        var sessionId = CreateSession();
+        using var request = CreateRequest(HttpMethod.Post, "/bff/content/write", sessionId);
+        request.Headers.Add("X-CSRF-TOKEN", "invalid-token");
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Logout_WhenNotLoggedIn_ReturnsNoContent()
+    {
+        var response = await _client.PostAsync("/bff/logout", null);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    private string CreateSession()
+    {
+        // 测试直接创建 BFF session，只验证浏览器 cookie 和 CSRF 边界，不依赖真实 Auth Server。
+        return _sessionStore.CreateSession(new TokenResponse(
+            "test-access-token",
+            "openid profile content.read content.write",
+            300));
+    }
+
+    private static HttpRequestMessage CreateRequest(HttpMethod method, string path, string sessionId)
+    {
+        var request = new HttpRequestMessage(method, path);
+        request.Headers.Add("Cookie", $"AuthFlowLab.Bff.Session={sessionId}");
+        return request;
+    }
+}

--- a/backend/AuthFlowLab.Bff/AuthFlowLab.Bff.csproj
+++ b/backend/AuthFlowLab.Bff/AuthFlowLab.Bff.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
+  </ItemGroup>
+
+</Project>

--- a/backend/AuthFlowLab.Bff/Controllers/BffController.cs
+++ b/backend/AuthFlowLab.Bff/Controllers/BffController.cs
@@ -1,0 +1,203 @@
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using AuthFlowLab.Bff.Models;
+using AuthFlowLab.Bff.Options;
+using AuthFlowLab.Bff.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace AuthFlowLab.Bff.Controllers;
+
+[ApiController]
+[Route("bff")]
+public sealed class BffController : ControllerBase
+{
+    private const string CsrfHeaderName = "X-CSRF-TOKEN";
+    private readonly BffOptions _options;
+    private readonly BffSessionStore _sessionStore;
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public BffController(
+        IOptions<BffOptions> options,
+        BffSessionStore sessionStore,
+        IHttpClientFactory httpClientFactory)
+    {
+        _options = options.Value;
+        _sessionStore = sessionStore;
+        _httpClientFactory = httpClientFactory;
+    }
+
+    [HttpGet("login")]
+    public IActionResult Login()
+    {
+        // BFF 自己生成并保存 PKCE verifier，浏览器只负责跟随重定向，不保存 OAuth token。
+        var verifier = Base64UrlEncoder.Encode(RandomNumberGenerator.GetBytes(32));
+        var challenge = Base64UrlEncoder.Encode(SHA256.HashData(Encoding.ASCII.GetBytes(verifier)));
+        var state = _sessionStore.CreateLoginState(verifier);
+        var nonce = Base64UrlEncoder.Encode(RandomNumberGenerator.GetBytes(16));
+
+        var authorizeUrl = QueryHelpers.AddQueryString(
+            $"{_options.AuthServerPublicUrl.TrimEnd('/')}/connect/authorize",
+            new Dictionary<string, string?>
+            {
+                ["response_type"] = "code",
+                ["client_id"] = _options.ClientId,
+                ["redirect_uri"] = _options.CallbackUrl,
+                ["scope"] = _options.Scope,
+                ["state"] = state,
+                ["nonce"] = nonce,
+                ["code_challenge"] = challenge,
+                ["code_challenge_method"] = "S256"
+            });
+
+        return Redirect(authorizeUrl);
+    }
+
+    [HttpGet("callback")]
+    public async Task<IActionResult> Callback([FromQuery] string? code, [FromQuery] string? state)
+    {
+        // callback 必须消费一次性 state，再由 BFF 服务端携带 secret 和 PKCE verifier 换 token。
+        if (string.IsNullOrWhiteSpace(code) ||
+            string.IsNullOrWhiteSpace(state) ||
+            !_sessionStore.TryConsumeLoginState(state, out var loginState) ||
+            loginState is null)
+        {
+            return BadRequest(new { error = "invalid_callback" });
+        }
+
+        var authServer = _httpClientFactory.CreateClient("AuthServer");
+        var response = await authServer.PostAsync("/connect/token", new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "authorization_code",
+            ["client_id"] = _options.ClientId,
+            ["client_secret"] = _options.ClientSecret,
+            ["code"] = code,
+            ["redirect_uri"] = _options.CallbackUrl,
+            ["code_verifier"] = loginState.CodeVerifier
+        }));
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return StatusCode((int)response.StatusCode, await response.Content.ReadAsStringAsync());
+        }
+
+        var token = await response.Content.ReadFromJsonAsync<TokenResponse>();
+        if (token is null)
+        {
+            return StatusCode(StatusCodes.Status502BadGateway, new { error = "invalid_token_response" });
+        }
+
+        var sessionId = _sessionStore.CreateSession(token);
+        Response.Cookies.Append(
+            _options.SessionCookieName,
+            sessionId,
+            CreateSessionCookieOptions(token.ExpiresIn));
+
+        return Redirect(_options.FrontendUrl);
+    }
+
+    [HttpGet("session")]
+    public IActionResult Session()
+    {
+        // 只返回页面需要的会话摘要和 CSRF token，不把服务端保存的 access_token 泄露给前端。
+        return TryGetCurrentSession(out var session)
+            ? Ok(new { authenticated = true, session.Scope, session.ExpiresAt, session.CsrfToken })
+            : Unauthorized(new { authenticated = false });
+    }
+
+    [HttpGet("content/read")]
+    public Task<IActionResult> ReadContent()
+        => ProxyApiRequest(HttpMethod.Get, "/content/read");
+
+    [HttpGet("content/me")]
+    public Task<IActionResult> ReadClaims()
+        => ProxyApiRequest(HttpMethod.Get, "/content/me");
+
+    [HttpPost("content/write")]
+    public Task<IActionResult> WriteContent()
+    {
+        // Cookie 会被浏览器自动携带，因此写请求必须额外校验前端显式发送的 CSRF token。
+        return ProxyApiRequest(HttpMethod.Post, "/content/write", requireCsrfToken: true);
+    }
+
+    [HttpGet("userinfo")]
+    public Task<IActionResult> UserInfo()
+        => ProxyRequest("AuthServer", HttpMethod.Get, "/connect/userinfo");
+
+    [HttpPost("logout")]
+    public IActionResult Logout()
+    {
+        // 退出时删除服务端 token session，并让浏览器删除只保存 session id 的 HttpOnly cookie。
+        Request.Cookies.TryGetValue(_options.SessionCookieName, out var sessionId);
+        _sessionStore.RemoveSession(sessionId);
+        Response.Cookies.Delete(_options.SessionCookieName);
+        return NoContent();
+    }
+
+    private Task<IActionResult> ProxyApiRequest(HttpMethod method, string path, bool requireCsrfToken = false)
+        => ProxyRequest("ApiServer", method, path, requireCsrfToken);
+
+    private async Task<IActionResult> ProxyRequest(
+        string clientName,
+        HttpMethod method,
+        string path,
+        bool requireCsrfToken = false)
+    {
+        // BFF 根据 cookie 找到服务端 token，再代理调用 Auth Server 或资源 API。
+        if (!TryGetCurrentSession(out var session))
+        {
+            return Unauthorized();
+        }
+
+        if (requireCsrfToken && !HasValidCsrfToken(session.CsrfToken))
+        {
+            return BadRequest(new { error = "invalid_csrf_token" });
+        }
+
+        var client = _httpClientFactory.CreateClient(clientName);
+        using var request = new HttpRequestMessage(method, path);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", session.AccessToken);
+        using var response = await client.SendAsync(request);
+
+        return new ContentResult
+        {
+            Content = await response.Content.ReadAsStringAsync(),
+            ContentType = response.Content.Headers.ContentType?.ToString() ?? "text/plain; charset=utf-8",
+            StatusCode = (int)response.StatusCode
+        };
+    }
+
+    private bool HasValidCsrfToken(string expectedToken)
+    {
+        var providedToken = Request.Headers[CsrfHeaderName].ToString();
+        if (string.IsNullOrWhiteSpace(providedToken))
+        {
+            return false;
+        }
+
+        return CryptographicOperations.FixedTimeEquals(
+            Encoding.UTF8.GetBytes(providedToken),
+            Encoding.UTF8.GetBytes(expectedToken));
+    }
+
+    private bool TryGetCurrentSession(out BffSession session)
+    {
+        Request.Cookies.TryGetValue(_options.SessionCookieName, out var sessionId);
+        return _sessionStore.TryGetSession(sessionId, out session!);
+    }
+
+    private CookieOptions CreateSessionCookieOptions(int expiresIn)
+    {
+        // 本地 HTTP 测试允许非 Secure；部署到 HTTPS 后自动写入 Secure cookie。
+        return new CookieOptions
+        {
+            HttpOnly = true,
+            SameSite = SameSiteMode.Lax,
+            Secure = Request.IsHttps,
+            Expires = DateTimeOffset.UtcNow.AddSeconds(expiresIn)
+        };
+    }
+}

--- a/backend/AuthFlowLab.Bff/Dockerfile
+++ b/backend/AuthFlowLab.Bff/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY backend/AuthFlowLab.Bff/AuthFlowLab.Bff.csproj backend/AuthFlowLab.Bff/
+RUN dotnet restore backend/AuthFlowLab.Bff/AuthFlowLab.Bff.csproj
+
+COPY backend/AuthFlowLab.Bff/ backend/AuthFlowLab.Bff/
+RUN dotnet publish backend/AuthFlowLab.Bff/AuthFlowLab.Bff.csproj -c Release -o /app/publish --no-restore
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
+WORKDIR /app
+COPY --from=build /app/publish .
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "AuthFlowLab.Bff.dll"]

--- a/backend/AuthFlowLab.Bff/Models/BffModels.cs
+++ b/backend/AuthFlowLab.Bff/Models/BffModels.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace AuthFlowLab.Bff.Models;
+
+// 登录跳转前暂存一次性 state 和 PKCE verifier，回调成功后立即消费，避免授权码回调被重复使用。
+public sealed record BffLoginState(string CodeVerifier, DateTimeOffset ExpiresAt);
+
+// 浏览器只持有随机 session id；access token 保存在 BFF 内存中，不暴露给前端 JavaScript。
+public sealed record BffSession(
+    string AccessToken,
+    string Scope,
+    DateTimeOffset ExpiresAt,
+    string CsrfToken);
+
+// BFF 使用该模型解析 Auth Server 的 token endpoint 返回值。
+public sealed record TokenResponse(
+    [property: JsonPropertyName("access_token")] string AccessToken,
+    [property: JsonPropertyName("scope")] string Scope,
+    [property: JsonPropertyName("expires_in")] int ExpiresIn);

--- a/backend/AuthFlowLab.Bff/Options/BffOptions.cs
+++ b/backend/AuthFlowLab.Bff/Options/BffOptions.cs
@@ -1,0 +1,28 @@
+namespace AuthFlowLab.Bff.Options;
+
+public sealed class BffOptions
+{
+    // 浏览器访问 Auth Server 时使用公开地址；Docker 容器内部地址不能暴露给浏览器。
+    public string AuthServerPublicUrl { get; init; } = "http://localhost:5001";
+
+    // BFF 服务端兑换 token 时使用后端地址，本地和 Docker 环境可以分别覆盖。
+    public string AuthServerBackchannelUrl { get; init; } = "http://localhost:5001";
+
+    // BFF 代理 API 请求时使用后端地址，本地和 Docker 环境可以分别覆盖。
+    public string ApiServerBackchannelUrl { get; init; } = "http://localhost:5002";
+
+    // callback 必须和 Auth Server 中 demo-bff client 注册的 redirect_uri 完全一致。
+    public string CallbackUrl { get; init; } = "http://localhost:5003/bff/callback";
+
+    // 登录完成后回到前端页面，由前端读取 BFF 会话状态。
+    public string FrontendUrl { get; init; } = "http://localhost:5173";
+
+    // BFF 是 confidential client，client_secret 只能保存在服务端。
+    public string ClientId { get; init; } = "demo-bff";
+    public string ClientSecret { get; init; } = "bff-secret";
+
+    // BFF 请求本地 Auth Server 发放的 API scopes。
+    public string Scope { get; init; } = "openid profile content.read content.write";
+
+    public string SessionCookieName { get; init; } = "AuthFlowLab.Bff.Session";
+}

--- a/backend/AuthFlowLab.Bff/Program.cs
+++ b/backend/AuthFlowLab.Bff/Program.cs
@@ -1,0 +1,52 @@
+using AuthFlowLab.Bff.Options;
+using AuthFlowLab.Bff.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+const string FrontendCorsPolicy = "Frontend";
+
+builder.Services.AddControllers();
+builder.Services.AddHealthChecks();
+builder.Services.Configure<BffOptions>(builder.Configuration.GetSection("Bff"));
+builder.Services.AddSingleton<BffSessionStore>();
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy(FrontendCorsPolicy, policy =>
+    {
+        var origins = builder.Configuration
+            .GetSection("Cors:AllowedOrigins")
+            .Get<string[]>() ?? ["http://localhost:5173"];
+
+        // 浏览器只携带 BFF 的 HttpOnly cookie，不直接接触 access_token。
+        policy.WithOrigins(origins)
+            .AllowAnyHeader()
+            .AllowAnyMethod()
+            .AllowCredentials();
+    });
+});
+
+builder.Services.AddHttpClient("AuthServer", (services, client) =>
+{
+    var options = services.GetRequiredService<Microsoft.Extensions.Options.IOptions<BffOptions>>().Value;
+    // BFF 在服务端调用 Auth Server token endpoint，用授权码兑换 access_token。
+    client.BaseAddress = new Uri(options.AuthServerBackchannelUrl);
+});
+
+builder.Services.AddHttpClient("ApiServer", (services, client) =>
+{
+    var options = services.GetRequiredService<Microsoft.Extensions.Options.IOptions<BffOptions>>().Value;
+    // BFF 代理调用 API 时才附加 bearer token，浏览器本身不会拿到这个 token。
+    client.BaseAddress = new Uri(options.ApiServerBackchannelUrl);
+});
+
+var app = builder.Build();
+
+app.UseCors(FrontendCorsPolicy);
+
+app.MapHealthChecks("/health");
+app.MapControllers();
+
+app.Run();
+
+public partial class Program;

--- a/backend/AuthFlowLab.Bff/Properties/launchSettings.json
+++ b/backend/AuthFlowLab.Bff/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5003",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7150;http://localhost:5003",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/backend/AuthFlowLab.Bff/Services/BffSessionStore.cs
+++ b/backend/AuthFlowLab.Bff/Services/BffSessionStore.cs
@@ -1,0 +1,71 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using AuthFlowLab.Bff.Models;
+using Microsoft.IdentityModel.Tokens;
+
+namespace AuthFlowLab.Bff.Services;
+
+public sealed class BffSessionStore
+{
+    private readonly ConcurrentDictionary<string, BffLoginState> _loginStates = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, BffSession> _sessions = new(StringComparer.Ordinal);
+
+    public string CreateLoginState(string codeVerifier)
+    {
+        // state 把 callback 绑定到 BFF 发起的登录请求，同时在服务端关联 PKCE verifier。
+        var state = CreateRandomValue();
+        _loginStates[state] = new BffLoginState(codeVerifier, DateTimeOffset.UtcNow.AddMinutes(5));
+        return state;
+    }
+
+    public bool TryConsumeLoginState(string state, out BffLoginState? loginState)
+    {
+        if (!_loginStates.TryRemove(state, out loginState))
+        {
+            return false;
+        }
+
+        return loginState.ExpiresAt > DateTimeOffset.UtcNow;
+    }
+
+    public string CreateSession(TokenResponse token)
+    {
+        // cookie 只保存随机 session id；真正的 access_token 和 CSRF token 保留在 BFF 服务端内存中。
+        var sessionId = CreateRandomValue();
+        _sessions[sessionId] = new BffSession(
+            token.AccessToken,
+            token.Scope,
+            DateTimeOffset.UtcNow.AddSeconds(token.ExpiresIn),
+            CreateRandomValue());
+        return sessionId;
+    }
+
+    public bool TryGetSession(string? sessionId, out BffSession? session)
+    {
+        session = null;
+        if (string.IsNullOrWhiteSpace(sessionId) || !_sessions.TryGetValue(sessionId, out var storedSession))
+        {
+            return false;
+        }
+
+        if (storedSession.ExpiresAt <= DateTimeOffset.UtcNow)
+        {
+            _sessions.TryRemove(sessionId, out _);
+            return false;
+        }
+
+        session = storedSession;
+        return true;
+    }
+
+    public void RemoveSession(string? sessionId)
+    {
+        if (!string.IsNullOrWhiteSpace(sessionId))
+        {
+            _sessions.TryRemove(sessionId, out _);
+        }
+    }
+
+    private static string CreateRandomValue()
+        => Base64UrlEncoder.Encode(RandomNumberGenerator.GetBytes(32));
+}

--- a/backend/AuthFlowLab.Bff/appsettings.Development.json
+++ b/backend/AuthFlowLab.Bff/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/backend/AuthFlowLab.Bff/appsettings.json
+++ b/backend/AuthFlowLab.Bff/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Bff": {
+    "AuthServerPublicUrl": "http://localhost:5001",
+    "AuthServerBackchannelUrl": "http://localhost:5001",
+    "ApiServerBackchannelUrl": "http://localhost:5002",
+    "CallbackUrl": "http://localhost:5003/bff/callback",
+    "FrontendUrl": "http://localhost:5173",
+    "ClientId": "demo-bff",
+    "ClientSecret": "bff-secret",
+    "Scope": "openid profile content.read content.write",
+    "SessionCookieName": "AuthFlowLab.Bff.Session"
+  },
+  "Cors": {
+    "AllowedOrigins": [ "http://localhost:5173" ]
+  },
+  "AllowedHosts": "*"
+}

--- a/backend/AuthFlowLab.sln
+++ b/backend/AuthFlowLab.sln
@@ -10,6 +10,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuthFlowLab.AuthServer.Test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuthFlowLab.ApiServer.Tests", "AuthFlowLab.ApiServer.Tests\AuthFlowLab.ApiServer.Tests.csproj", "{BBCFFA6A-D319-485F-A63A-9DD43B7F5289}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuthFlowLab.Bff", "AuthFlowLab.Bff\AuthFlowLab.Bff.csproj", "{3E75BFFC-7302-43E6-9964-F6E08F27307E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuthFlowLab.Bff.Tests", "AuthFlowLab.Bff.Tests\AuthFlowLab.Bff.Tests.csproj", "{90827BDE-1D11-44A2-8F2B-474F1775DC29}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -32,5 +36,13 @@ Global
         {BBCFFA6A-D319-485F-A63A-9DD43B7F5289}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {BBCFFA6A-D319-485F-A63A-9DD43B7F5289}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {BBCFFA6A-D319-485F-A63A-9DD43B7F5289}.Release|Any CPU.Build.0 = Release|Any CPU
+        {3E75BFFC-7302-43E6-9964-F6E08F27307E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {3E75BFFC-7302-43E6-9964-F6E08F27307E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {3E75BFFC-7302-43E6-9964-F6E08F27307E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {3E75BFFC-7302-43E6-9964-F6E08F27307E}.Release|Any CPU.Build.0 = Release|Any CPU
+        {90827BDE-1D11-44A2-8F2B-474F1775DC29}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {90827BDE-1D11-44A2-8F2B-474F1775DC29}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {90827BDE-1D11-44A2-8F2B-474F1775DC29}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {90827BDE-1D11-44A2-8F2B-474F1775DC29}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
 EndGlobal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,25 @@ services:
     depends_on:
       - auth-server
 
+  # BFF 在服务端保存 access token，浏览器只通过 HttpOnly cookie 访问 BFF。
+  bff:
+    build:
+      context: .
+      dockerfile: backend/AuthFlowLab.Bff/Dockerfile
+    environment:
+      ASPNETCORE_URLS: http://+:8080
+      Bff__AuthServerPublicUrl: http://localhost:5001
+      Bff__AuthServerBackchannelUrl: http://auth-server:8080
+      Bff__ApiServerBackchannelUrl: http://api-server:8080
+      Bff__CallbackUrl: http://localhost:5003/bff/callback
+      Bff__FrontendUrl: http://localhost:5173
+      Cors__AllowedOrigins__0: http://localhost:5173
+    ports:
+      - "5003:8080"
+    depends_on:
+      - auth-server
+      - api-server
+
   frontend:
     build:
       context: frontend/AuthFlowLab.Web
@@ -37,3 +56,4 @@ services:
     depends_on:
       - auth-server
       - api-server
+      - bff

--- a/frontend/AuthFlowLab.Web/src/App.tsx
+++ b/frontend/AuthFlowLab.Web/src/App.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useMemo, useState } from 'react';
-import { apiServer, authServer } from './config';
+import { apiServer, authServer, bffServer } from './config';
 import {
   decodeJwtPayload,
   getApiToken,
   getGraphAccessToken,
   initializeAuthState,
+  logoutBffSession,
   logoutSession,
+  readBffSession,
   readTokens,
+  startBffLogin,
   startEntraLogin,
   startLogin
 } from './auth';
@@ -14,10 +17,11 @@ import { LoginPanel } from './components/LoginPanel';
 import { ResultPanel } from './components/ResultPanel';
 import { SessionPanel } from './components/SessionPanel';
 import { TokenPanel } from './components/TokenPanel';
-import type { CallResult, TokenResponse } from './types';
+import type { BffSessionResponse, CallResult, TokenResponse } from './types';
 
 export function App() {
   const [tokens, setTokens] = useState<TokenResponse | null>(() => readTokens());
+  const [bffSession, setBffSession] = useState<BffSessionResponse | null>(null);
   const [message, setMessage] = useState('');
   const [result, setResult] = useState<CallResult | null>(null);
 
@@ -28,6 +32,18 @@ export function App() {
   const accessTokenPayload = useMemo(() => {
     return tokens?.access_token ? decodeJwtPayload(tokens.access_token) : null;
   }, [tokens]);
+
+  useEffect(() => {
+    // 页面加载后检查 BFF 的 HttpOnly cookie，用独立状态表示服务端 token 会话。
+    void readBffSession()
+      .then((session) => {
+        if (session) {
+          setBffSession(session);
+          setMessage('BFF session ready.');
+        }
+      })
+      .catch((error: Error) => setMessage(error.message));
+  }, []);
 
   useEffect(() => {
     void initializeAuthState()
@@ -74,7 +90,35 @@ export function App() {
     await startEntraLogin();
   }
 
+  function handleBffLogin() {
+    setMessage('');
+    setResult(null);
+    startBffLogin();
+  }
+
   async function callApi(path: string, label: string, method = 'GET') {
+    // BFF 模式统一走服务端代理；写请求额外携带 CSRF token。
+    if (bffSession) {
+      const bffPath = path === `${apiServer}/content/read`
+        ? '/bff/content/read'
+        : path === `${apiServer}/content/me`
+          ? '/bff/content/me'
+          : '/bff/content/write';
+      const response = await fetch(`${bffServer}${bffPath}`, {
+        method,
+        credentials: 'include',
+        headers: method === 'POST'
+          ? { 'X-CSRF-TOKEN': bffSession.csrfToken }
+          : undefined
+      });
+      setResult({
+        label: `BFF ${bffPath} -> ${label}`,
+        status: response.status,
+        body: await response.text()
+      });
+      return;
+    }
+
     if (!tokens?.access_token) {
       setMessage('Login first.');
       return;
@@ -100,6 +144,18 @@ export function App() {
   }
 
   async function callUserInfo() {
+    if (bffSession) {
+      const response = await fetch(`${bffServer}/bff/userinfo`, {
+        credentials: 'include'
+      });
+      setResult({
+        label: 'BFF /bff/userinfo -> AuthServer /connect/userinfo',
+        status: response.status,
+        body: await response.text()
+      });
+      return;
+    }
+
     if (!tokens?.access_token) {
       setMessage('Login first.');
       return;
@@ -126,28 +182,36 @@ export function App() {
   }
 
   async function logout() {
-    // 中文注释：Logout 同时清除前端 token 和 Auth Server cookie，下一次 Local Login 才会重新显示登录页。
+    // Logout 同时清除 SPA token、Auth Server cookie 和 BFF 服务端 token session。
+    await logoutBffSession();
     await logoutSession();
     setTokens(null);
+    setBffSession(null);
     setResult(null);
     setMessage('Logged out.');
   }
+
+  const browserTokens = bffSession ? null : tokens;
+  const browserIdTokenPayload = bffSession ? null : idTokenPayload;
+  const browserAccessTokenPayload = bffSession ? null : accessTokenPayload;
 
   return (
     <main className="app-shell">
       <LoginPanel
         message={message}
         onLogout={() => void logout()}
+        onBffLogin={handleBffLogin}
         onEntraLogin={() => void handleEntraLogin()}
         onLogin={() => void handleLogin()}
       />
 
-      {/* 中文注释：Claims 按钮会调用 /content/me，查看 token 在 API 中被解析成哪些 Identity 和 Claims。 */}
+      {/* Claims 按钮会调用 /content/me，查看 token 在 API 中被解析成哪些 Identity 和 Claims。 */}
       <SessionPanel
-        accessTokenPayload={accessTokenPayload}
-        idTokenPayload={idTokenPayload}
-        provider={tokens?.provider}
-        isAuthenticated={Boolean(tokens)}
+        accessTokenPayload={browserAccessTokenPayload}
+        idTokenPayload={browserIdTokenPayload}
+        provider={bffSession ? 'bff' : tokens?.provider}
+        serverSideScope={bffSession?.scope}
+        isAuthenticated={Boolean(bffSession ?? tokens)}
         onCallApi={() => void callApi(`${apiServer}/content/read`, 'ApiServer /content/read')}
         onCallClaims={() => void callApi(`${apiServer}/content/me`, 'ApiServer /content/me')}
         onCallWriteApi={() => void callApi(`${apiServer}/content/write`, 'ApiServer /content/write', 'POST')}
@@ -156,11 +220,11 @@ export function App() {
 
       <ResultPanel result={result} />
       <TokenPanel
-        accessToken={tokens?.access_token}
-        accessTokenPayload={accessTokenPayload}
-        idToken={tokens?.id_token}
-        idTokenPayload={idTokenPayload}
-        provider={tokens?.provider}
+        accessToken={browserTokens?.access_token}
+        accessTokenPayload={browserAccessTokenPayload}
+        idToken={browserTokens?.id_token}
+        idTokenPayload={browserIdTokenPayload}
+        provider={browserTokens?.provider}
       />
     </main>
   );

--- a/frontend/AuthFlowLab.Web/src/auth.ts
+++ b/frontend/AuthFlowLab.Web/src/auth.ts
@@ -4,8 +4,8 @@ import {
   type AccountInfo,
   type AuthenticationResult
 } from '@azure/msal-browser';
-import { authServer, clientId, entra, redirectUri, scope, storageKeys } from './config';
-import type { TokenResponse } from './types';
+import { authServer, bffServer, clientId, entra, redirectUri, scope, storageKeys } from './config';
+import type { BffSessionResponse, TokenResponse } from './types';
 
 export const msalInstance = new PublicClientApplication({
   auth: {
@@ -51,6 +51,36 @@ export async function startEntraLogin() {
   await msalReady;
   await msalInstance.loginRedirect({
     scopes: [...entra.apiScopes]
+  });
+}
+
+export function startBffLogin() {
+  // BFF 自己负责授权码交换和 token 保存，浏览器只需要跟随登录跳转。
+  window.location.assign(`${bffServer}/bff/login`);
+}
+
+export async function readBffSession() {
+  // HttpOnly cookie 会由浏览器自动发送，前端只能读取会话状态，不能读取 cookie 或 access token。
+  const response = await fetch(`${bffServer}/bff/session`, {
+    credentials: 'include'
+  });
+
+  if (response.status === 401) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`BFF session check failed: HTTP ${response.status}`);
+  }
+
+  return (await response.json()) as BffSessionResponse;
+}
+
+export async function logoutBffSession() {
+  // 退出 BFF 会话时让服务端删除 token session，并让浏览器删除 HttpOnly cookie。
+  await fetch(`${bffServer}/bff/logout`, {
+    method: 'POST',
+    credentials: 'include'
   });
 }
 
@@ -192,7 +222,7 @@ export function clearSession() {
 }
 
 export async function logoutSession() {
-  // 中文注释：完整退出要让 Auth Server 删除 HttpOnly cookie；只清 token 不会清掉 IdP 登录会话。
+  // 完整退出要让 Auth Server 删除 HttpOnly cookie；只清 token 不会清掉 IdP 登录会话。
   await fetch(`${authServer}/account/logout`, {
     method: 'POST',
     credentials: 'include'

--- a/frontend/AuthFlowLab.Web/src/components/LoginPanel.tsx
+++ b/frontend/AuthFlowLab.Web/src/components/LoginPanel.tsx
@@ -2,6 +2,7 @@ type LoginPanelProps = {
   message: string;
   onLogin: () => void;
   onEntraLogin: () => void;
+  onBffLogin: () => void;
   onLogout: () => void;
 };
 
@@ -9,6 +10,7 @@ export function LoginPanel({
   message,
   onLogin,
   onEntraLogin,
+  onBffLogin,
   onLogout
 }: LoginPanelProps) {
   return (
@@ -19,7 +21,7 @@ export function LoginPanel({
       </div>
 
       <p className="muted">
-        Sign in with the local lab IdP or Entra ID. The SPA starts the authorization request and stores demo tokens locally.
+        Compare browser token storage with a BFF session that keeps the access token on the server.
       </p>
 
       <div className="button-row">
@@ -28,6 +30,9 @@ export function LoginPanel({
         </button>
         <button type="button" className="btn btn-primary" onClick={onEntraLogin}>
           Entra Login
+        </button>
+        <button type="button" className="btn btn-primary" onClick={onBffLogin}>
+          BFF Login
         </button>
         <button type="button" className="btn btn-outline" onClick={onLogout}>
           Logout

--- a/frontend/AuthFlowLab.Web/src/components/SessionPanel.tsx
+++ b/frontend/AuthFlowLab.Web/src/components/SessionPanel.tsx
@@ -3,7 +3,8 @@ import { stringClaim } from '../format';
 type SessionPanelProps = {
   accessTokenPayload: Record<string, unknown> | null;
   idTokenPayload: Record<string, unknown> | null;
-  provider?: 'local' | 'entra';
+  provider?: 'local' | 'entra' | 'bff';
+  serverSideScope?: string;
   isAuthenticated: boolean;
   onCallApi: () => void;
   onCallClaims: () => void;
@@ -15,6 +16,7 @@ export function SessionPanel({
   accessTokenPayload,
   idTokenPayload,
   provider,
+  serverSideScope,
   isAuthenticated,
   onCallApi,
   onCallClaims,
@@ -35,14 +37,14 @@ export function SessionPanel({
         <ClaimItem label="ID Token Audience" value={stringClaim(idTokenPayload?.aud)} />
         <ClaimItem label="Access Token Issuer" value={stringClaim(accessTokenPayload?.iss)} />
         <ClaimItem label="Access Token Audience" value={stringClaim(accessTokenPayload?.aud)} />
-        <ClaimItem label="Access Token Scope" value={stringClaim(accessTokenPayload?.scp ?? accessTokenPayload?.scope)} />
+        <ClaimItem label="Access Token Scope" value={serverSideScope ?? stringClaim(accessTokenPayload?.scp ?? accessTokenPayload?.scope)} />
       </dl>
 
       <div className="button-row">
         <button type="button" className="btn btn-primary" onClick={onCallApi}>
           Call Read API
         </button>
-        {/* 中文注释：Claims 按钮用于查看 API Server 认证后的服务端 claims，而不是只看浏览器里解码的 JWT。 */}
+        {/* Claims 按钮用于查看 API Server 认证后的服务端 claims，而不是只看浏览器里解码的 JWT。 */}
         <button type="button" className="btn btn-primary" onClick={onCallClaims}>
           Claims
         </button>

--- a/frontend/AuthFlowLab.Web/src/components/TokenPanel.tsx
+++ b/frontend/AuthFlowLab.Web/src/components/TokenPanel.tsx
@@ -19,7 +19,7 @@ export function TokenPanel({
     <section className="card content-card">
       <h2>Token Inspector</h2>
 
-      {/* 中文注释：这里解码浏览器当前持有的 JWT，帮助对比本地 IdP token 和 Entra ID token 的 issuer、audience、scope。 */}
+      {/* 这里解码浏览器当前持有的 JWT，帮助对比本地 IdP token 和 Entra ID token 的 issuer、audience、scope。 */}
       <dl className="claim-list">
         <ClaimItem label="Provider" value={provider ?? inferProvider(accessTokenPayload)} />
         <ClaimItem label="Issuer" value={stringClaim(accessTokenPayload?.iss)} />
@@ -56,7 +56,7 @@ function TokenBlock({ label, value }: { label: string; value?: string }) {
 }
 
 function inferProvider(payload: Record<string, unknown> | null) {
-  // 中文注释：根据 issuer 粗略推断 token 来自 Entra ID 还是本地 AuthServer；最终安全判断仍由 API Server 的 JWT 验证完成。
+  // 根据 issuer 粗略推断 token 来自 Entra ID 还是本地 AuthServer；最终安全判断仍由 API Server 的 JWT 验证完成。
   const issuer = stringClaim(payload?.iss);
   if (issuer.startsWith('https://login.microsoftonline.com/') || issuer.startsWith('https://sts.windows.net/')) {
     return 'entra';

--- a/frontend/AuthFlowLab.Web/src/config.ts
+++ b/frontend/AuthFlowLab.Web/src/config.ts
@@ -1,5 +1,6 @@
 export const authServer = 'http://localhost:5001';
 export const apiServer = 'http://localhost:5002';
+export const bffServer = 'http://localhost:5003';
 
 // Local AuthFlowLab IdP public client. SPA clients do not store client_secret.
 export const clientId = 'demo-spa';
@@ -11,7 +12,7 @@ export const entra = {
   clientId: '35b46efc-ba76-4940-bc2a-a4fa1b904dcb',
   authority: 'https://login.microsoftonline.com/976c3c85-e425-4880-a658-3653df9cebf2/v2.0',
   redirectUri: 'http://localhost:5173/callback',
-  // 中文注释：当前 Azure API 只暴露 read scope；Direct Entra Login 暂时只请求读权限，避免缺少 write_as_user scope 导致登录失败。
+  // 当前 Azure API 只暴露 read scope；Direct Entra Login 暂时只请求读权限，避免缺少 write_as_user scope 导致登录失败。
   apiScopes: [
     'api://b5b7fdde-0835-4e46-863d-463b1432e9f7/access_as_user'
   ],

--- a/frontend/AuthFlowLab.Web/src/main.tsx
+++ b/frontend/AuthFlowLab.Web/src/main.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+﻿import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import './styles.css';
 
-// 中文注释: React 入口只负责挂载应用，业务逻辑放在 App 和组件文件中。
+//  React 入口只负责挂载应用，业务逻辑放在 App 和组件文件中。
 createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />

--- a/frontend/AuthFlowLab.Web/src/types.ts
+++ b/frontend/AuthFlowLab.Web/src/types.ts
@@ -12,3 +12,10 @@ export type CallResult = {
   status: number;
   body: string;
 };
+
+export type BffSessionResponse = {
+  authenticated: boolean;
+  scope: string;
+  expiresAt: string;
+  csrfToken: string;
+};


### PR DESCRIPTION
## Summary
- add an ASP.NET Core BFF that exchanges authorization codes server-side and stores access tokens in an in-memory session
- expose an HttpOnly session cookie to the browser and proxy read, claims, write, and UserInfo requests
- protect BFF write requests with an `X-CSRF-TOKEN` check
- add SPA BFF login mode, Docker wiring, focused tests, and concise README documentation

## Validation
- `dotnet test backend/AuthFlowLab.sln`
- `npm run build`
- `docker compose -f docker-compose.yml -f docker-compose.local.yml up -d --build`
- verified BFF read, claims, UserInfo, CSRF rejection, authorized write, logout, and post-logout session behavior